### PR TITLE
fixes for CI tests restarting after previously failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # <div align="center"> OpenMSIStream </div>
-#### <div align="center">***v1.1.5***</div>
+#### <div align="center">***v1.1.6***</div>
 
 #### <div align="center">Maggie Eminizer<sup>1</sup>, Sam Tabrisky<sup>2,3,4</sup>, Amir Sharifzadeh<sup>1</sup>, Christopher DiMarco<sup>4</sup>, Jacob M. Diamond<sup>4,6</sup>, K.T. Ramesh<sup>4</sup>, Todd C. Hufnagel<sup>4,5,6</sup>, Tyrel M. McQueen<sup>4,5,7,8</sup>, David Elbert<sup>1,4</sup></div>
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #imports
 import setuptools, site
 
-version = '1.1.5'
+version = '1.1.6'
 
 site.ENABLE_USER_SITE = True #https://www.scivision.dev/python-pip-devel-user-install/
 

--- a/test/unittests/test_data_file_stream_processor.py
+++ b/test/unittests/test_data_file_stream_processor.py
@@ -129,7 +129,8 @@ class TestDataFileStreamProcessor(unittest.TestCase) :
         """
         Test restarting a DataFileStreamProcessor from the beginning of the topic after failing to process a file
         """
-        self.assertFalse(TEST_CONST.TEST_STREAM_PROCESSOR_OUTPUT_DIR_RESTART.is_dir())
+        if TEST_CONST.TEST_STREAM_PROCESSOR_OUTPUT_DIR_RESTART.is_dir() :
+            shutil.rmtree(TEST_CONST.TEST_STREAM_PROCESSOR_OUTPUT_DIR_RESTART)
         TOPIC_NAME = TEST_CONST.TEST_TOPIC_NAMES['test_data_file_stream_processor_restart_kafka']
         CONSUMER_GROUP_ID = 'test_data_file_stream_processor_restart'
         #upload the data files

--- a/test/unittests/test_data_file_stream_processor_encrypted.py
+++ b/test/unittests/test_data_file_stream_processor_encrypted.py
@@ -23,12 +23,17 @@ class TestDataFileStreamProcessorEncyrpted(unittest.TestCase) :
         """
         Test restarting an encrypted DataFileStreamProcessor after failing to process a file
         """
-        self.assertFalse(TEST_CONST.TEST_STREAM_PROCESSOR_OUTPUT_DIR_RESTART_ENCRYPTED.is_dir())
+        to_remove = [
+            TEST_CONST.TEST_STREAM_PROCESSOR_OUTPUT_DIR_RESTART_ENCRYPTED,
+            TEST_CONST.TEST_STREAM_PROC_WATCHED_DIR_PATH_ENCRYPTED,
+            ]
+        for remove_dir in to_remove :
+            if remove_dir.is_dir() :
+                shutil.rmtree(remove_dir)
         TOPIC_NAME = TEST_CONST.TEST_TOPIC_NAMES['test_data_file_stream_processor_restart_encrypted_kafka']
         CONSUMER_GROUP_ID = 'test_data_file_stream_processor_restart_encrypted'
         #make the directory to watch
         watched_subdir = TEST_CONST.TEST_STREAM_PROC_WATCHED_DIR_PATH_ENCRYPTED/TEST_CONST.TEST_DATA_FILE_SUB_DIR_NAME
-        self.assertFalse(watched_subdir.parent.is_dir())
         watched_subdir.mkdir(parents=True)
         #start up the DataFileUploadDirectory
         dfud = DataFileUploadDirectory(TEST_CONST.TEST_STREAM_PROC_WATCHED_DIR_PATH_ENCRYPTED,

--- a/test/unittests/test_services.py
+++ b/test/unittests/test_services.py
@@ -132,7 +132,8 @@ class TestServices(unittest.TestCase) :
         test_file_path = TEST_CONST.TEST_DIR_CUSTOM_RUNNABLE_SERVICE_TEST/'runnable_example_service_test.txt'
         error_log_path = pathlib.Path().resolve()/f'{service_name}{SERVICE_CONST.ERROR_LOG_STEM}'
         service_path = SERVICE_CONST.DAEMON_SERVICE_DIR/f'{service_name}.service'
-        self.assertFalse(test_file_path.exists())
+        if test_file_path.exists() :
+            test_file_path.unlink()
         try :
             install_service_main(
                 ['RunnableExample=openmsistream.services.examples.runnable_example',
@@ -174,7 +175,8 @@ class TestServices(unittest.TestCase) :
         service_name = 'ScriptExampleServiceTest'
         test_file_path = TEST_CONST.TEST_DIR_CUSTOM_SCRIPT_SERVICE_TEST/'script_example_service_test.txt'
         error_log_path = pathlib.Path().resolve()/f'{service_name}{SERVICE_CONST.ERROR_LOG_STEM}'
-        self.assertFalse(test_file_path.exists())
+        if test_file_path.exists() :
+            test_file_path.unlink()
         try :
             install_service_main(
                 ['openmsistream.services.examples.script_example:main',


### PR DESCRIPTION
This PR stops CI tests from failing if their expected working directories exist before the test begins. I had had that functionality in there to make it easier to inspect test output, but it's not necessary or helpful in the general use case. If those directories exist when a new test run is initiated on a system, they'll be removed and replaced and the test won't fail anymore.