### PR TITLE
Fix typo in GirderUploadStreamProcessor command args

### DIFF
--- a/openmsistream/girder/girder_upload_stream_processor.py
+++ b/openmsistream/girder/girder_upload_stream_processor.py
@@ -300,7 +300,7 @@ class GirderUploadStreamProcessor(DataFileStreamProcessor):
             args.topic_name,
             girder_root_folder_id=args.girder_root_folder_id,
             collection_name=args.collection_name,
-            girder_root_folder=args.girder_root_folder,
+            girder_root_folder_path=args.girder_root_folder_path,
             provider=args.provider,
             output_dir=args.output_dir,
             mode=args.mode,


### PR DESCRIPTION
A typo in `GirderUploadStreamProcessor` instantiation prevents it to be used from a command line.

### How to reproduce?

```
openmsi@shakuras:/example$ GirderUploadStreamProcessor --config /example/test.config --topic_name openmsistream_tutorial_data --girder_root_folder_id 656768c1e6466b105e830a15 https://girder.local.wholetale.org/api/v1 ipXTpwvyGvYfKgbOWRXxtDqgB1i2qiEpaaTPArCq
```

### Expected results
```
GirderUploadStreamProcessor 2023-11-29 18:30:06] Log files and output will be in GirderUploadStreamProcessor_output
[GirderUploadStreamProcessor 2023-11-29 18:30:07] Listening to the openmsistream_tutorial_data topic for files to upload to Girder using the API at https://girder.local.wholetale.org/api/v1
[GirderUploadStreamProcessor 2023-11-29 18:30:07] Will process files from messages in the openmsistream_tutorial_data topic using 2 threads
```

### Actual results
```
Traceback (most recent call last):
  File "/usr/local/bin/GirderUploadStreamProcessor", line 8, in <module>
    sys.exit(main())
  File "/home/openmsi/.local/lib/python3.9/site-packages/openmsistream/girder/girder_upload_stream_processor.py", line 350, in main
    GirderUploadStreamProcessor.run_from_command_line(args)
  File "/home/openmsi/.local/lib/python3.9/site-packages/openmsistream/girder/girder_upload_stream_processor.py", line 303, in run_from_command_line
    girder_root_folder=args.girder_root_folder,
AttributeError: 'Namespace' object has no attribute 'girder_root_folder'
```