### PR TITLE
Pass arbitrary metadata to Girder uploads

### DIFF
--- a/openmsistream/utilities/argument_parsing.py
+++ b/openmsistream/utilities/argument_parsing.py
@@ -269,12 +269,12 @@ class OpenMSIStreamArgumentParser(OpenMSIArgumentParser):
                 ),
             },
         ],
-        "provider": [
+        "metadata": [
             "optional",
             {
                 "help": (
-                    'Adding this argument will add a corresponding "provider" metadata '
-                    "field to all created folders and items"
+                    "Adding this argument will add a corresponding metadata "
+                    "field to all created folders and items. Assumes JSON serialized string."
                 ),
             },
         ],

--- a/test/test_scripts/test_girder_upload_stream_processor.py
+++ b/test/test_scripts/test_girder_upload_stream_processor.py
@@ -1,4 +1,5 @@
 # imports
+import json
 import time, subprocess, unittest
 from hashlib import sha512
 import requests, docker, girder_client  # pylint: disable=wrong-import-order
@@ -145,7 +146,7 @@ class TestGirderUploadStreamProcessor(
             ),
             other_init_kwargs={
                 "collection_name": COLLECTION_NAME,
-                "provider": "test_provider",
+                "metadata": json.dumps({"somekey": "somevalue"}),
             },
         )
         self.start_stream_processor_thread()
@@ -198,6 +199,7 @@ class TestGirderUploadStreamProcessor(
             resps = girder.listItem(topic_folder_id)
             item_id = None
             for resp in resps:
+                self.assertEqual(resp["meta"].get("somekey"), "somevalue")
                 item_id = resp["_id"]
             if not item_id:
                 raise RuntimeError(f"Couldn't find Item! Responses: {list(resps)}")


### PR DESCRIPTION
This PR allows to specify an arbitrary metadata stamped on files uploaded via `GirderUploadStreamProcessor`. My main use case is provenance tracking, but I'm fairly certain it will be useful in other scenarios.