### PR TITLE
Set mimeType for files uploaded with Girder stream processor

### DIFF
--- a/openmsistream/girder/girder_upload_stream_processor.py
+++ b/openmsistream/girder/girder_upload_stream_processor.py
@@ -1,11 +1,14 @@
 # imports
 import json
-from io import BytesIO
+import mimetypes
 from hashlib import sha256
+from io import BytesIO
+
 import girder_client
-from ..version import __version__
+
 from ..data_file_io.actor.data_file_stream_processor import DataFileStreamProcessor
 from ..utilities.config import RUN_CONST
+from ..version import __version__
 
 
 class GirderUploadStreamProcessor(DataFileStreamProcessor):
@@ -144,16 +147,19 @@ class GirderUploadStreamProcessor(DataFileStreamProcessor):
         # Upload the file from its bytestring or file on disk
         try:
             with lock:
+                mimetype, _ = mimetypes.guess_type(datafile.filename)
+                mimetype = mimetype or "application/octet-stream"
                 try:
                     self.__girder_client.uploadStreamToFolder(
                         parent_id,
                         BytesIO(datafile.bytestring),
                         datafile.filename,
                         len(datafile.bytestring),
+                        mimeType=mimetype,
                     )
                 except AttributeError:
                     self.__girder_client.uploadFileToFolder(
-                        parent_id, datafile.full_filepath
+                        parent_id, datafile.full_filepath, mimeType=mimetype
                     )
         except Exception as exc:
             errmsg = f"ERROR: failed to upload the file at {datafile.relative_filepath}"

--- a/test/stop_local_broker.sh
+++ b/test/stop_local_broker.sh
@@ -2,4 +2,4 @@
 
 set -euxo pipefail
 
-docker compose -f local-kafka-broker-docker-compose.yml down 
+docker compose -f local-kafka-broker-docker-compose.yml down -t 0


### PR DESCRIPTION
### Motivation

If `mimeType` is not provided to Girder client's upload method, it gets set to a default `application/octet-stream`. This results in "Item Previews" not functioning properly for `.png` files and not rendering them by default.

### Proposed solution
Use `mimetype` module from Python's standard library to guess mime type based on file's extension. It might be wrong, but 8/10 times should be good enough. Alternative would be to use something like `python-magic`.

### Notes
* This PR is rebased on #66, hence some duplicated commits. This should fix itself provided that that PR is merged.

### How to test?
1. Stream a png file using GirderStreamProcessor.
2. Confirm that resulting `file` object in girder has a mimeType `image/png`. 