### PR TITLE
Use context manager to handle locks. Fixes #101

### DIFF
--- a/openmsistream/data_file_io/actor/file_registry/producer_file_registry.py
+++ b/openmsistream/data_file_io/actor/file_registry/producer_file_registry.py
@@ -172,18 +172,20 @@ class ProducerFileRegistry(LogOwner):
         Returns True if all chunks for the file have been produced
         """
         # acquire the lock so no other threads can change the in progress file
-        self.__in_prog.lock.acquire()
-        # get a dictionary of the existing object addresses keyed by their filepaths
-        existing_obj_addresses = self.__in_prog.obj_addresses_by_key_attr("rel_filepath")
-        # if the file is already recognized as in progress
-        if rel_filepath in existing_obj_addresses:
-            return self.__register_chunk_of_existing_file(
+        with self.__in_prog.lock:
+            # get a dictionary of the existing object addresses keyed by their filepaths
+            existing_obj_addresses = self.__in_prog.obj_addresses_by_key_attr(
+                "rel_filepath"
+            )
+            # if the file is already recognized as in progress
+            if rel_filepath in existing_obj_addresses:
+                return self.__register_chunk_of_existing_file(
+                    filename, rel_filepath, n_total_chunks, chunk_i, prodid
+                )
+            # otherwise it's a new file to list somewhere
+            return self.__register_chunk_for_new_file(
                 filename, rel_filepath, n_total_chunks, chunk_i, prodid
             )
-        # otherwise it's a new file to list somewhere
-        return self.__register_chunk_for_new_file(
-            filename, rel_filepath, n_total_chunks, chunk_i, prodid
-        )
 
     def __register_chunk_of_existing_file(
         self, filename, rel_filepath, n_total_chunks, chunk_i, prodid
@@ -200,7 +202,6 @@ class ProducerFileRegistry(LogOwner):
                 f"ERROR: found {len(existing_obj_addresses[rel_filepath])} files in the "
                 f"producer registry for filepath {rel_filepath}"
             )
-            self.__in_prog.lock.release()
             self.logger.error(errmsg, exc_type=RuntimeError)
         existing_addr = existing_obj_addresses[rel_filepath][0]
         # make sure the total numbers of chunks match
@@ -211,7 +212,6 @@ class ProducerFileRegistry(LogOwner):
                 f"{existing_n_chunks} total chunks, but the producer callback for this "
                 f"file lists {n_total_chunks} chunks! Did the chunk size change?"
             )
-            self.__in_prog.lock.release()
             self.logger.error(errmsg, exc_type=RuntimeError)
         # get its current state
         attrs = self.__in_prog.get_entry_attrs(
@@ -219,7 +219,6 @@ class ProducerFileRegistry(LogOwner):
         )
         # if the chunk is already registered, just return
         if chunk_i in attrs["chunks_delivered"]:
-            self.__in_prog.lock.release()
             return False
         # otherwise add/remove it from the sets
         attrs["chunks_delivered"].add(chunk_i)
@@ -249,9 +248,7 @@ class ProducerFileRegistry(LogOwner):
             self.__add_completed_entry(completed_entry, prodid)
             self.__in_prog.remove_entries(existing_addr)
             self.__in_prog.dump_to_file()
-            self.__in_prog.lock.release()
             return True
-        self.__in_prog.lock.release()
         return False
 
     def __register_chunk_for_new_file(
@@ -279,10 +276,8 @@ class ProducerFileRegistry(LogOwner):
             )
             self.__in_prog.add_entries(in_prog_entry)
             self.__in_prog.dump_to_file()
-            self.__in_prog.lock.release()
             return False
         # otherwise register it as a completed file
-        self.__in_prog.lock.release()
         completed_entry = RegistryLineCompleted(
             filename,
             rel_filepath,

--- a/openmsistream/data_file_io/actor/file_registry/stream_handler_registries.py
+++ b/openmsistream/data_file_io/actor/file_registry/stream_handler_registries.py
@@ -297,35 +297,34 @@ class StreamProcessorRegistry(StreamHandlerRegistry):
         """
         Add/update a line in the table to show that a file has successfully been processed
         """
-        self._in_progress_table.lock.acquire()
-        existing_entry_addr = self._get_in_progress_address_for_rel_filepath(
-            dfc.relative_filepath
-        )
-        if existing_entry_addr is not None:
-            attrs = self._in_progress_table.get_entry_attrs(existing_entry_addr)
-            new_entry = StreamHandlerRegistryLineSucceeded(
-                attrs["filename"],
-                attrs["rel_filepath"],
-                attrs["n_chunks"],
-                attrs["first_message"],
-                datetime.datetime.now(),
+        with self._in_progress_table.lock:
+            existing_entry_addr = self._get_in_progress_address_for_rel_filepath(
+                dfc.relative_filepath
             )
-            self._add_to_succeeded_table(new_entry)
-            try:
-                self._in_progress_table.remove_entries(existing_entry_addr)
-                self._in_progress_table.dump_to_file()
-            except ValueError:
-                pass
-        else:
-            new_entry = StreamHandlerRegistryLineSucceeded(
-                dfc.filename,
-                dfc.relative_filepath,
-                dfc.n_total_chunks,
-                datetime.datetime.now(),
-                datetime.datetime.now(),
-            )
-            self._add_to_succeeded_table(new_entry)
-        self._in_progress_table.lock.release()
+            if existing_entry_addr is not None:
+                attrs = self._in_progress_table.get_entry_attrs(existing_entry_addr)
+                new_entry = StreamHandlerRegistryLineSucceeded(
+                    attrs["filename"],
+                    attrs["rel_filepath"],
+                    attrs["n_chunks"],
+                    attrs["first_message"],
+                    datetime.datetime.now(),
+                )
+                self._add_to_succeeded_table(new_entry)
+                try:
+                    self._in_progress_table.remove_entries(existing_entry_addr)
+                    self._in_progress_table.dump_to_file()
+                except ValueError:
+                    pass
+            else:
+                new_entry = StreamHandlerRegistryLineSucceeded(
+                    dfc.filename,
+                    dfc.relative_filepath,
+                    dfc.n_total_chunks,
+                    datetime.datetime.now(),
+                    datetime.datetime.now(),
+                )
+                self._add_to_succeeded_table(new_entry)
 
     def register_file_processing_failed(self, dfc):
         """
@@ -369,33 +368,34 @@ class StreamReproducerRegistry(StreamHandlerRegistry):
         """
         Add/update a line in the table to show that a file has successfully been processed
         """
-        self._in_progress_table.lock.acquire()
-        existing_entry_addr = self._get_in_progress_address_for_rel_filepath(rel_filepath)
-        if existing_entry_addr is not None:
-            attrs = self._in_progress_table.get_entry_attrs(existing_entry_addr)
-            new_entry = StreamHandlerRegistryLineSucceeded(
-                attrs["filename"],
-                attrs["rel_filepath"],
-                attrs["n_chunks"],
-                attrs["first_message"],
-                datetime.datetime.now(),
+        with self._in_progress_table.lock:
+            existing_entry_addr = self._get_in_progress_address_for_rel_filepath(
+                rel_filepath
             )
-            self._add_to_succeeded_table(new_entry, f"p{prodid}")
-            try:
-                self._in_progress_table.remove_entries(existing_entry_addr)
-                self._in_progress_table.dump_to_file()
-            except ValueError:
-                pass
-        else:
-            new_entry = StreamHandlerRegistryLineSucceeded(
-                filename,
-                rel_filepath,
-                n_total_chunks,
-                datetime.datetime.now(),
-                datetime.datetime.now(),
-            )
-            self._add_to_succeeded_table(new_entry, f"p{prodid}")
-        self._in_progress_table.lock.release()
+            if existing_entry_addr is not None:
+                attrs = self._in_progress_table.get_entry_attrs(existing_entry_addr)
+                new_entry = StreamHandlerRegistryLineSucceeded(
+                    attrs["filename"],
+                    attrs["rel_filepath"],
+                    attrs["n_chunks"],
+                    attrs["first_message"],
+                    datetime.datetime.now(),
+                )
+                self._add_to_succeeded_table(new_entry, f"p{prodid}")
+                try:
+                    self._in_progress_table.remove_entries(existing_entry_addr)
+                    self._in_progress_table.dump_to_file()
+                except ValueError:
+                    pass
+            else:
+                new_entry = StreamHandlerRegistryLineSucceeded(
+                    filename,
+                    rel_filepath,
+                    n_total_chunks,
+                    datetime.datetime.now(),
+                    datetime.datetime.now(),
+                )
+                self._add_to_succeeded_table(new_entry, f"p{prodid}")
 
     def register_file_computing_result_failed(
         self, filename, rel_filepath, n_total_chunks

--- a/openmsistream/utilities/dataclass_table.py
+++ b/openmsistream/utilities/dataclass_table.py
@@ -5,10 +5,17 @@ dataclass objects serialized to/deseralized from a corresponding CSV file in an 
 """
 
 # imports
-import pathlib, functools, datetime, typing, copy, os, time
+import copy
+import datetime
+import functools
+import os
+import pathlib
+import time
+import typing
 from abc import ABC
-from threading import Lock
 from dataclasses import fields, is_dataclass
+from threading import RLock
+
 import methodtools
 from atomicwrites import atomic_write
 from openmsitoolbox import LogOwner
@@ -66,7 +73,7 @@ class DataclassTableBase(LogOwner, ABC):
         # init the LogOwner
         super().__init__(**kwargs)
         # create the thread lock for the table
-        self.lock = Lock()
+        self.lock = RLock()
         # figure out what type of objects the table/file will be describing
         self.__dataclass_type = dataclass_type
         if not is_dataclass(self.__dataclass_type):
@@ -177,17 +184,12 @@ class DataclassTableBase(LogOwner, ABC):
             )
             self.logger.error(errmsg, exc_type=ValueError)
         to_return = {}
-        locked_internally = False
-        if not self.lock.locked():
-            self.lock.acquire()
-            locked_internally = True
-        for addr, obj in self._entry_objs.items():
-            rkey = getattr(obj, key_attr_name)
-            if rkey not in to_return:
-                to_return[rkey] = []
-            to_return[rkey].append(addr)
-        if locked_internally:
-            self.lock.release()
+        with self.lock:
+            for addr, obj in self._entry_objs.items():
+                rkey = getattr(obj, key_attr_name)
+                if rkey not in to_return:
+                    to_return[rkey] = []
+                to_return[rkey].append(addr)
         return to_return
 
     def dump_to_file(self, reraise_exc=True, retries=2):
@@ -205,13 +207,8 @@ class DataclassTableBase(LogOwner, ABC):
         lines_to_write = [self.csv_header_line]
         if len(self._entry_lines) > 0:
             lines_to_write += list(self._entry_lines.values())
-        locked_internally = False
-        if not self.lock.locked():
-            locked_internally = True
-            self.lock.acquire()
-        self.__write_lines(lines_to_write, reraise_exc=reraise_exc, retries=retries)
-        if locked_internally:
-            self.lock.release()
+        with self.lock:
+            self.__write_lines(lines_to_write, reraise_exc=reraise_exc, retries=retries)
 
     #################### PROPERTIES ####################
 
@@ -318,13 +315,13 @@ class DataclassTableBase(LogOwner, ABC):
                 if reraise_exc:
                     errmsg = (
                         f"ERROR: failed to write to {self.__class__.__name__} csv file at "
-                        f"{self.__filepath} after {retries-n_retries_left+1} attempts! "
+                        f"{self.__filepath} after {retries - n_retries_left + 1} attempts! "
                         "Will reraise exception."
                     )
                     self.logger.error(errmsg, exc_info=caught_exc, reraise=True)
                 else:
                     msg = (
-                        f"WARNING: failed in {retries-n_retries_left+1} attempts to write "
+                        f"WARNING: failed in {retries - n_retries_left + 1} attempts to write "
                         f"to {self.__class__.__name__} csv file at {self.__filepath}! "
                         "Exception info below"
                     )
@@ -455,22 +452,15 @@ class DataclassTableAppendOnly(DataclassTableBase):
         """
         if is_dataclass(new_entries):
             new_entries = [new_entries]
-        for entry in new_entries:
-            entry_addr = hex(id(entry))
-            if entry_addr in self._entry_objs or entry_addr in self._entry_lines:
-                errmsg = (
-                    "ERROR: address of object sent to add_entries is already registered!"
-                )
-                self.logger.error(errmsg, exc_type=ValueError)
-            locked_internally = False
-            if not self.lock.locked():
-                locked_internally = True
-                self.lock.acquire()
-            self._entry_objs[entry_addr] = entry
-            self._entry_lines[entry_addr] = self._line_from_obj(entry)
-            self.obj_addresses_by_key_attr.cache_clear()
-            if locked_internally:
-                self.lock.release()
+        with self.lock:
+            for entry in new_entries:
+                entry_addr = hex(id(entry))
+                if entry_addr in self._entry_objs or entry_addr in self._entry_lines:
+                    errmsg = "ERROR: address of object sent to add_entries is already registered!"
+                    self.logger.error(errmsg, exc_type=ValueError)
+                self._entry_objs[entry_addr] = entry
+                self._entry_lines[entry_addr] = self._line_from_obj(entry)
+                self.obj_addresses_by_key_attr.cache_clear()
         if (
             datetime.datetime.now() - self._file_last_updated
         ).total_seconds() > self.UPDATE_FILE_EVERY:
@@ -520,21 +510,19 @@ class DataclassTable(DataclassTableAppendOnly):
         """
         if isinstance(entry_obj_addresses, str):
             entry_obj_addresses = [entry_obj_addresses]
-        for entry_addr in entry_obj_addresses:
-            if (entry_addr not in self._entry_objs) or (
-                entry_addr not in self._entry_lines
-            ):
-                errmsg = f"ERROR: address {entry_addr} sent to remove_entries is not registered!"
-                self.logger.error(errmsg, exc_type=ValueError)
-            locked_internally = False
-            if not self.lock.locked():
-                locked_internally = True
-                self.lock.acquire()
-            self._entry_objs.pop(entry_addr)
-            self._entry_lines.pop(entry_addr)
-            self.obj_addresses_by_key_attr.cache_clear()
-            if locked_internally:
-                self.lock.release()
+        with self.lock:
+            for entry_addr in entry_obj_addresses:
+                if (entry_addr not in self._entry_objs) or (
+                    entry_addr not in self._entry_lines
+                ):
+                    errmsg = (
+                        f"ERROR: address {entry_addr} sent "
+                        "to remove_entries is not registered!"
+                    )
+                    self.logger.error(errmsg, exc_type=ValueError)
+                self._entry_objs.pop(entry_addr)
+                self._entry_lines.pop(entry_addr)
+                self.obj_addresses_by_key_attr.cache_clear()
         if (
             datetime.datetime.now() - self._file_last_updated
         ).total_seconds() > self.UPDATE_FILE_EVERY:
@@ -557,17 +545,12 @@ class DataclassTable(DataclassTableAppendOnly):
                 f"ERROR: address {entry_obj_address} is not registered!",
                 exc_type=ValueError,
             )
-        locked_internally = False
-        if not self.lock.locked():
-            locked_internally = True
-            self.lock.acquire()
-        obj = self._entry_objs[entry_obj_address]
-        for fname, fval in kwargs.items():
-            setattr(obj, fname, fval)
-        self._entry_lines[entry_obj_address] = self._line_from_obj(obj)
-        self.obj_addresses_by_key_attr.cache_clear()
-        if locked_internally:
-            self.lock.release()
+        with self.lock:
+            obj = self._entry_objs[entry_obj_address]
+            for fname, fval in kwargs.items():
+                setattr(obj, fname, fval)
+            self._entry_lines[entry_obj_address] = self._line_from_obj(obj)
+            self.obj_addresses_by_key_attr.cache_clear()
         if (
             datetime.datetime.now() - self._file_last_updated
         ).total_seconds() > self.UPDATE_FILE_EVERY:

--- a/openmsistream/utilities/dataclass_table.py
+++ b/openmsistream/utilities/dataclass_table.py
@@ -204,10 +204,10 @@ class DataclassTableBase(LogOwner, ABC):
         :param retries: how many times to retry writing out the file
         :type retries: int, optional
         """
-        lines_to_write = [self.csv_header_line]
-        if len(self._entry_lines) > 0:
-            lines_to_write += list(self._entry_lines.values())
         with self.lock:
+            lines_to_write = [self.csv_header_line]
+            if len(self._entry_lines) > 0:
+                lines_to_write += list(self._entry_lines.values())
             self.__write_lines(lines_to_write, reraise_exc=reraise_exc, retries=retries)
 
     #################### PROPERTIES ####################
@@ -461,10 +461,10 @@ class DataclassTableAppendOnly(DataclassTableBase):
                 self._entry_objs[entry_addr] = entry
                 self._entry_lines[entry_addr] = self._line_from_obj(entry)
                 self.obj_addresses_by_key_attr.cache_clear()
-        if (
-            datetime.datetime.now() - self._file_last_updated
-        ).total_seconds() > self.UPDATE_FILE_EVERY:
-            self.dump_to_file()
+            if (
+                datetime.datetime.now() - self._file_last_updated
+            ).total_seconds() > self.UPDATE_FILE_EVERY:
+                self.dump_to_file()
 
     def as_read_only(self):
         """
@@ -523,10 +523,10 @@ class DataclassTable(DataclassTableAppendOnly):
                 self._entry_objs.pop(entry_addr)
                 self._entry_lines.pop(entry_addr)
                 self.obj_addresses_by_key_attr.cache_clear()
-        if (
-            datetime.datetime.now() - self._file_last_updated
-        ).total_seconds() > self.UPDATE_FILE_EVERY:
-            self.dump_to_file()
+            if (
+                datetime.datetime.now() - self._file_last_updated
+            ).total_seconds() > self.UPDATE_FILE_EVERY:
+                self.dump_to_file()
 
     def set_entry_attrs(self, entry_obj_address, **kwargs):
         """
@@ -551,7 +551,7 @@ class DataclassTable(DataclassTableAppendOnly):
                 setattr(obj, fname, fval)
             self._entry_lines[entry_obj_address] = self._line_from_obj(obj)
             self.obj_addresses_by_key_attr.cache_clear()
-        if (
-            datetime.datetime.now() - self._file_last_updated
-        ).total_seconds() > self.UPDATE_FILE_EVERY:
-            self.dump_to_file()
+            if (
+                datetime.datetime.now() - self._file_last_updated
+            ).total_seconds() > self.UPDATE_FILE_EVERY:
+                self.dump_to_file()

--- a/test/test_scripts/test_metadata_reproducer.py
+++ b/test/test_scripts/test_metadata_reproducer.py
@@ -1,38 +1,30 @@
-# imports
-import pathlib
 import datetime
-import json
-import pickle
-import urllib.request
-import time
 import importlib.machinery
-
-import logging
+import json
+import pathlib
+import pickle
+import time
+import urllib.request
 
 import pytest
-
-from openmsitoolbox.logging.openmsi_logger import OpenMSILogger
 from openmsitoolbox.utilities.exception_tracking_thread import ExceptionTrackingThread
 from openmsistream.kafka_wrapper import ConsumerAndProducerGroup
 
-try:
-    from .config import TEST_CONST
-except ImportError:
-    from config import TEST_CONST
+from .config import TEST_CONST
 
 
 # ----------------------------------------------------------------------
 # Dynamically load XRDCSVMetadataReproducer
 # ----------------------------------------------------------------------
 
-class_path = (
+_class_path = (
     TEST_CONST.EXAMPLES_DIR_PATH
     / "extracting_metadata"
     / "xrd_csv_metadata_reproducer.py"
 )
-module_name = class_path.stem
-loader = importlib.machinery.SourceFileLoader(module_name, str(class_path))
-module = loader.load_module()  # pylint: disable=deprecated-method,no-value-for-parameter
+module = importlib.machinery.SourceFileLoader(  # pylint: disable=deprecated-method,no-value-for-parameter
+    _class_path.stem, str(_class_path)
+).load_module()
 
 
 # ----------------------------------------------------------------------
@@ -40,26 +32,84 @@ module = loader.load_module()  # pylint: disable=deprecated-method,no-value-for-
 # ----------------------------------------------------------------------
 
 TIMEOUT_SECS = 90
-
 REP_CONFIG_PATH = (
     TEST_CONST.EXAMPLES_DIR_PATH
     / "extracting_metadata"
-    / "test_xrd_csv_metadata_reproducer.config"
+    / "local_broker_test_xrd_csv_metadata_reproducer.config"
 )
-
-REP_CONFIG_PATH = REP_CONFIG_PATH.with_name(f"local_broker_{REP_CONFIG_PATH.name}")
-
 UPLOAD_FILE = TEST_CONST.EXAMPLES_DIR_PATH / "extracting_metadata" / "SC001_XRR.csv"
-
 CONSUMER_GROUP_ID = f"test_metadata_reproducer_{TEST_CONST.PY_VERSION}"
-
-# Timestamp format matching str(datetime.datetime.now())
 TIMESTAMP_FMT = "%Y-%m-%d %H:%M:%S.%f"
-
 SOURCE_TOPIC_NAME = "test_metadata_extractor_source"
 DEST_TOPIC_NAME = "test_metadata_extractor_dest"
 HEARTBEAT_TOPIC_NAME = "heartbeats"
 LOG_TOPIC_NAME = "logs"
+PROGRAM_ID = "reproducer"
+
+TOPICS = {
+    SOURCE_TOPIC_NAME: {},
+    DEST_TOPIC_NAME: {},
+    HEARTBEAT_TOPIC_NAME: {"--partitions": 1},
+    LOG_TOPIC_NAME: {"--partitions": 1},
+}
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def create_reproducer(state, logger):
+    output_dir = state["tmp_path"] / "reproducer"
+    output_dir.mkdir()
+    state["reproducer"] = module.XRDCSVMetadataReproducer(
+        REP_CONFIG_PATH,
+        SOURCE_TOPIC_NAME,
+        DEST_TOPIC_NAME,
+        output_dir=output_dir,
+        consumer_group_id=CONSUMER_GROUP_ID,
+        logger=logger,
+        heartbeat_topic_name=HEARTBEAT_TOPIC_NAME,
+        heartbeat_program_id=PROGRAM_ID,
+        heartbeat_interval_secs=1,
+        log_topic_name=LOG_TOPIC_NAME,
+        log_program_id=PROGRAM_ID,
+        log_interval_secs=1,
+    )
+    return state["reproducer"]
+
+
+def start_reproducer_thread(state):
+    thread = ExceptionTrackingThread(
+        target=state["reproducer"].produce_processing_results_for_files_as_read
+    )
+    thread.start()
+    state["reproducer_thread"] = thread
+
+
+def stop_reproducer(state, timeout_secs=30):
+    state["reproducer"].control_command_queue.put("q")
+    state["reproducer_thread"].join(timeout=timeout_secs)
+    if state["reproducer_thread"].is_alive():
+        raise TimeoutError(f"Reproducer thread timed out after {timeout_secs} seconds")
+
+
+def wait_for_reproducer_results(state, rel_filepaths, timeout_secs=TIMEOUT_SECS):
+    if isinstance(rel_filepaths, pathlib.PurePath):
+        rel_filepaths = [rel_filepaths]
+    found = {p: False for p in rel_filepaths}
+    start = time.time()
+    rep = state["reproducer"]
+    while not all(found.values()) and (time.time() - start) < timeout_secs:
+        for p in list(found):
+            if not found[p] and p in rep.recent_results_produced:
+                found[p] = True
+        time.sleep(0.25)
+    if not all(found.values()):
+        raise TimeoutError(
+            f"Files not processed within {timeout_secs} seconds: "
+            + str([p for p, v in found.items() if not v])
+        )
 
 
 # ----------------------------------------------------------------------
@@ -68,313 +118,146 @@ LOG_TOPIC_NAME = "logs"
 
 
 @pytest.fixture(scope="module")
-def stream_reproducer_factory(tmp_path_factory):
-    """Factory fixture that creates a DataFileStreamReproducer subclass instance,
-    stores it, and returns a handle with start()/stop() methods."""
-
-    class _Handle:
-        def __init__(self, reproducer):
-            self.reproducer = reproducer
-            self._thread = None
-
-        def start(self):
-            self._thread = ExceptionTrackingThread(
-                target=self.reproducer.produce_processing_results_for_files_as_read
-            )
-            self._thread.start()
-
-        def stop(self):
-            if self.reproducer:
-                self.reproducer.control_command_queue.put("q")
-            if self._thread:
-                self._thread.join(timeout=30)
-
-    _logger = OpenMSILogger(
-        logger_name="test_metadata_reproducer",
-        streamlevel=logging.DEBUG,
-        logger_filepath=None,
-        filelevel=logging.DEBUG,
-        conf_global_logger=False,
-    )
-
-    class _Factory:
-        def __init__(self):
-            self._handle = None
-
-        def __call__(
-            self,
-            reproducer_type,
-            cfg_file,
-            source_topic_name,
-            dest_topic_name,
-            consumer_group_id="create_new",
-            other_init_kwargs=None,
-        ):
-            if other_init_kwargs is None:
-                other_init_kwargs = {}
-            output_dir = tmp_path_factory.mktemp("reproducer")
-            rep = reproducer_type(
-                cfg_file,
-                source_topic_name,
-                dest_topic_name,
-                output_dir=output_dir,
-                consumer_group_id=consumer_group_id,
-                logger=_logger,
-                **other_init_kwargs,
-            )
-            self._handle = _Handle(rep)
-            return self._handle
-
-        @property
-        def reproducer(self):
-            return self._handle.reproducer if self._handle else None
-
-    return _Factory()
-
-
-@pytest.fixture
-def stream_reproducer(start_metadata_reproducer, stream_reproducer_factory):
-    """Returns the actual reproducer instance created by the factory."""
-    return stream_reproducer_factory.reproducer
-
-
-@pytest.fixture(scope="module")
-def wait_for_files_to_be_processed(stream_reproducer_factory):
-    """Returns a callable that blocks until the given file paths appear in
-    recent_processed_filepaths on the running reproducer."""
-
-    def _wait(rel_filepaths, timeout_secs=90):
-        if isinstance(rel_filepaths, pathlib.PurePath):
-            rel_filepaths = [rel_filepaths]
-        found = {p: False for p in rel_filepaths}
-        start = time.time()
-        rep = stream_reproducer_factory.reproducer
-        while not all(found.values()) and (time.time() - start) < timeout_secs:
-            for p in list(found):
-                if not found[p] and p in rep.recent_results_produced:
-                    found[p] = True
-            time.sleep(0.25)
-        if not all(found.values()):
-            raise TimeoutError(
-                f"Files not processed within {timeout_secs} seconds: "
-                + str([p for p, v in found.items() if not v])
-            )
-
-    return _wait
-
-
-@pytest.fixture(scope="module")
 def downloaded_upload_file():
-    """Download test CSV once per module."""
-    urllib.request.urlretrieve(
-        TEST_CONST.TUTORIAL_TEST_FILE_URL,
-        UPLOAD_FILE,
-    )
+    """Download the test CSV file once for the whole module."""
+    urllib.request.urlretrieve(TEST_CONST.TUTORIAL_TEST_FILE_URL, UPLOAD_FILE)
     yield UPLOAD_FILE
     if UPLOAD_FILE.exists():
         UPLOAD_FILE.unlink()
 
 
-@pytest.fixture
-def start_metadata_reproducer(kafka_topics, stream_reproducer_factory):
-    """Start the metadata reproducer after topics are ready."""
-    program_id = "reproducer"
-
-    reproducer = stream_reproducer_factory(
-        module.XRDCSVMetadataReproducer,
-        cfg_file=REP_CONFIG_PATH,
-        source_topic_name=SOURCE_TOPIC_NAME,
-        dest_topic_name=DEST_TOPIC_NAME,
-        consumer_group_id=CONSUMER_GROUP_ID,
-        other_init_kwargs={
-            "heartbeat_topic_name": HEARTBEAT_TOPIC_NAME,
-            "heartbeat_program_id": program_id,
-            "heartbeat_interval_secs": 1,
-            "log_topic_name": LOG_TOPIC_NAME,
-            "log_program_id": program_id,
-            "log_interval_secs": 1,
-        },
-    )
-
-    reproducer.start()
-    yield program_id
-    reproducer.stop()
-
-
 # ----------------------------------------------------------------------
-# Helper functions
+# Test
 # ----------------------------------------------------------------------
-def run_metadata_reproducer_flow(
-    upload_file_helper,
-    wait_for_files_to_be_processed,
-    stream_reproducer,
-):
-    """Shared logic to upload file and wait for processing."""
-    upload_file_helper(UPLOAD_FILE, topic_name=SOURCE_TOPIC_NAME)
-
-    recofp = pathlib.Path(UPLOAD_FILE.name)
-    wait_for_files_to_be_processed(recofp)
-
-    in_progress_table = stream_reproducer.file_registry.in_progress_table
-    succeeded_table = stream_reproducer.file_registry.succeeded_table
-
-    in_progress_table.dump_to_file()
-    succeeded_table.dump_to_file()
-
-    assert len(stream_reproducer.file_registry.filepaths_to_rerun) == 0
-
-    time.sleep(5)
-
-    in_prog_entries = in_progress_table.obj_addresses_by_key_attr("status")
-    succeeded_entries = succeeded_table.obj_addresses
-
-    assert len(succeeded_entries) >= 1
-    assert stream_reproducer.file_registry.PRODUCING_MESSAGE_FAILED not in in_prog_entries
-    assert stream_reproducer.file_registry.COMPUTING_RESULT_FAILED not in in_prog_entries
-
-    succeeded_attrs = succeeded_table.get_entry_attrs(succeeded_entries[0])
-    assert succeeded_attrs["filename"] == UPLOAD_FILE.name
 
 
-# ----------------------------------------------------------------------
-# Tests
-# ----------------------------------------------------------------------
 @pytest.mark.kafka
-@pytest.mark.parametrize(
-    "kafka_topics",
-    [
-        {
-            SOURCE_TOPIC_NAME: {},
-            DEST_TOPIC_NAME: {},
-            HEARTBEAT_TOPIC_NAME: {"--partitions": 1},
-            LOG_TOPIC_NAME: {"--partitions": 1},
-        }
-    ],
-    indirect=True,
-)
+@pytest.mark.parametrize("kafka_topics", [TOPICS], indirect=True)
+@pytest.mark.usefixtures("kafka_topics", "apply_kafka_env")
 def test_metadata_reproducer_kafka(
-    kafka_topics,
+    state,
+    logger,
     downloaded_upload_file,
-    start_metadata_reproducer,
     upload_file_helper,
-    wait_for_files_to_be_processed,
-    stream_reproducer,
     get_heartbeat_messages,
     get_log_messages,
 ):
-    program_id = start_metadata_reproducer
-
-    start_time = datetime.datetime.now()
-    start_time_uts = time.time()
-
-    run_metadata_reproducer_flow(
-        upload_file_helper,
-        wait_for_files_to_be_processed,
-        stream_reproducer,
-    )
-
-    consumer_group = ConsumerAndProducerGroup(
-        TEST_CONST.TEST_CFG_FILE_PATH_MDC,
-        consumer_topic_name=DEST_TOPIC_NAME,
-        consumer_group_id=CONSUMER_GROUP_ID,
-    )
-
-    consumer = consumer_group.get_new_subscribed_consumer()
-
     try:
-        success = False
-        consume_start = datetime.datetime.now()
-        msg = None
+        # --- Upload the test file and wait for it to be processed ---
+        upload_file_helper(UPLOAD_FILE, topic_name=SOURCE_TOPIC_NAME)
+        time.sleep(2)
 
-        while (
-            not success
-            and (datetime.datetime.now() - consume_start).total_seconds() < TIMEOUT_SECS
-        ):
-            msg = consumer.get_next_message()
-            if msg is None:
-                continue
+        create_reproducer(state, logger)
+        start_reproducer_thread(state)
+        start_time = datetime.datetime.now()
+        start_time_uts = time.time()
+        wait_for_reproducer_results(state, pathlib.Path(UPLOAD_FILE.name))
 
-            msg_dict = json.loads(msg.value())
-            created_at = datetime.datetime.strptime(
-                msg_dict["metadata_message_generated_at"],
-                "%m/%d/%Y, %H:%M:%S",
-            )
-
-            if (created_at - start_time).total_seconds() > 0:
-                with open(TEST_CONST.TEST_METADATA_DICT_PICKLE_FILE, "rb") as fp:
-                    ref_dict = pickle.load(fp)
-
-                matches = sum(1 for k, v in ref_dict.items() if msg_dict.get(k) == v)
-                success = matches == len(ref_dict)
-
-        assert msg is not None, (
-            f"Could not consume metadata message from {DEST_TOPIC_NAME} "
-            f"within {TIMEOUT_SECS} seconds"
+        # --- Validate file registry ---
+        registry = state["reproducer"].file_registry
+        in_progress_table = registry.in_progress_table
+        succeeded_table = registry.succeeded_table
+        in_progress_table.dump_to_file()
+        succeeded_table.dump_to_file()
+        assert len(registry.filepaths_to_rerun) == 0
+        time.sleep(5)
+        in_prog_entries = in_progress_table.obj_addresses_by_key_attr("status")
+        succeeded_entries = succeeded_table.obj_addresses
+        assert len(succeeded_entries) >= 1
+        assert registry.PRODUCING_MESSAGE_FAILED not in in_prog_entries
+        assert registry.COMPUTING_RESULT_FAILED not in in_prog_entries
+        assert (
+            succeeded_table.get_entry_attrs(succeeded_entries[0])["filename"]
+            == UPLOAD_FILE.name
         )
-        assert success, "Consumed metadata does not match reference"
+
+        # --- Validate metadata message on destination topic ---
+        consumer_group = ConsumerAndProducerGroup(
+            TEST_CONST.TEST_CFG_FILE_PATH_MDC,
+            consumer_topic_name=DEST_TOPIC_NAME,
+            consumer_group_id=CONSUMER_GROUP_ID,
+        )
+        consumer = consumer_group.get_new_subscribed_consumer()
+        try:
+            success = False
+            msg = None
+            consume_start = datetime.datetime.now()
+            while (
+                not success
+                and (datetime.datetime.now() - consume_start).total_seconds()
+                < TIMEOUT_SECS
+            ):
+                msg = consumer.get_next_message(1)  # 1-second poll timeout
+                if msg is None:
+                    continue
+                msg_dict = json.loads(msg.value())
+                created_at = datetime.datetime.strptime(
+                    msg_dict["metadata_message_generated_at"], "%m/%d/%Y, %H:%M:%S"
+                )
+                if (created_at - start_time).total_seconds() > 0:
+                    with open(TEST_CONST.TEST_METADATA_DICT_PICKLE_FILE, "rb") as fp:
+                        ref_dict = pickle.load(fp)
+                    success = sum(
+                        1 for k, v in ref_dict.items() if msg_dict.get(k) == v
+                    ) == len(ref_dict)
+            assert msg is not None, (
+                f"Could not consume metadata message from {DEST_TOPIC_NAME} "
+                f"within {TIMEOUT_SECS} seconds"
+            )
+            assert success, "Consumed metadata does not match reference"
+        finally:
+            consumer.close()
+
+        # --- Validate heartbeats ---
+        heartbeat_msgs = get_heartbeat_messages(
+            TEST_CONST.TEST_CFG_FILE_PATH_HEARTBEATS,
+            HEARTBEAT_TOPIC_NAME,
+            PROGRAM_ID,
+            per_wait_secs=5,
+        )
+        assert len(heartbeat_msgs) > 0
+        totals = {
+            k: 0
+            for k in (
+                "read_msgs",
+                "read_bytes",
+                "proc_msgs",
+                "proc_bytes",
+                "prod_msgs",
+                "prod_bytes",
+            )
+        }
+        for msg in heartbeat_msgs:
+            msg_dict = json.loads(msg.value())
+            assert (
+                datetime.datetime.strptime(msg_dict["timestamp"], TIMESTAMP_FMT)
+                > start_time
+            )
+            totals["read_msgs"] += msg_dict["n_messages_read"]
+            totals["read_bytes"] += msg_dict["n_bytes_read"]
+            totals["proc_msgs"] += msg_dict["n_messages_processed"]
+            totals["proc_bytes"] += msg_dict["n_bytes_processed"]
+            totals["prod_msgs"] += msg_dict["n_messages_produced"]
+            totals["prod_bytes"] += msg_dict["n_bytes_produced"]
+        test_file_size = UPLOAD_FILE.stat().st_size
+        test_chunks = int(test_file_size / TEST_CONST.TEST_CHUNK_SIZE)
+        assert totals["read_msgs"] >= test_chunks
+        assert totals["read_bytes"] >= test_file_size
+        assert totals["proc_msgs"] >= test_chunks
+        assert totals["proc_bytes"] >= test_file_size
+        assert totals["prod_msgs"] == 1
+        assert totals["prod_bytes"] > 700
+
+        # --- Validate logs ---
+        log_msgs = get_log_messages(
+            TEST_CONST.TEST_CFG_FILE_PATH_LOGS,
+            LOG_TOPIC_NAME,
+            PROGRAM_ID,
+            per_wait_secs=5,
+        )
+        assert len(log_msgs) > 0
+        for msg in log_msgs:
+            assert float(json.loads(msg.value())["timestamp"]) >= start_time_uts
 
     finally:
-        consumer.close()
-
-    # ------------------------------------------------------------------
-    # Validate heartbeats
-    # ------------------------------------------------------------------
-
-    heartbeat_msgs = get_heartbeat_messages(
-        TEST_CONST.TEST_CFG_FILE_PATH_HEARTBEATS,
-        HEARTBEAT_TOPIC_NAME,
-        program_id,
-        per_wait_secs=5,
-    )
-
-    assert len(heartbeat_msgs) > 0
-
-    totals = {
-        "read_msgs": 0,
-        "read_bytes": 0,
-        "proc_msgs": 0,
-        "proc_bytes": 0,
-        "prod_msgs": 0,
-        "prod_bytes": 0,
-    }
-
-    for msg in heartbeat_msgs:
-        msg_dict = json.loads(msg.value())
-        ts = datetime.datetime.strptime(
-            msg_dict["timestamp"],
-            TIMESTAMP_FMT,
-        )
-        assert ts > start_time
-
-        totals["read_msgs"] += msg_dict["n_messages_read"]
-        totals["read_bytes"] += msg_dict["n_bytes_read"]
-        totals["proc_msgs"] += msg_dict["n_messages_processed"]
-        totals["proc_bytes"] += msg_dict["n_bytes_processed"]
-        totals["prod_msgs"] += msg_dict["n_messages_produced"]
-        totals["prod_bytes"] += msg_dict["n_bytes_produced"]
-
-    test_file_size = UPLOAD_FILE.stat().st_size
-    test_chunks = int(test_file_size / TEST_CONST.TEST_CHUNK_SIZE)
-
-    assert totals["read_msgs"] >= test_chunks
-    assert totals["read_bytes"] >= test_file_size
-    assert totals["proc_msgs"] >= test_chunks
-    assert totals["proc_bytes"] >= test_file_size
-    assert totals["prod_msgs"] == 1
-    assert totals["prod_bytes"] > 700
-
-    # ------------------------------------------------------------------
-    # Validate logs
-    # ------------------------------------------------------------------
-
-    log_msgs = get_log_messages(
-        TEST_CONST.TEST_CFG_FILE_PATH_LOGS,
-        LOG_TOPIC_NAME,
-        program_id,
-        per_wait_secs=5,
-    )
-
-    assert len(log_msgs) > 0
-    for msg in log_msgs:
-        msg_dict = json.loads(msg.value())
-        assert float(msg_dict["timestamp"]) >= start_time_uts
+        stop_reproducer(state)


### PR DESCRIPTION
Using context manager for handling thread locks avoids a situation where something bad happens and lock is never released.