### PR TITLE
Add --replace_existing flag to GirderUploadStreamProcessor

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -470,7 +470,7 @@ max-attributes=20
 max-bool-expr=10 #5
 
 # Maximum number of branch for function / method body.
-max-branches=15
+max-branches=20
 
 # Maximum number of locals for function / method body.
 max-locals=30

--- a/.pylintrc
+++ b/.pylintrc
@@ -470,7 +470,7 @@ max-attributes=20
 max-bool-expr=10 #5
 
 # Maximum number of branch for function / method body.
-max-branches=20
+max-branches=13
 
 # Maximum number of locals for function / method body.
 max-locals=30

--- a/openmsistream/girder/girder_upload_stream_processor.py
+++ b/openmsistream/girder/girder_upload_stream_processor.py
@@ -289,6 +289,13 @@ class GirderUploadStreamProcessor(DataFileStreamProcessor):
                 )
                 self.logger.error(errmsg, exc_info=exc)
                 return exc
+        elif existing_item:
+            self.logger.warning(
+                f"WARNING: found an existing Item named {datafile.filename} with a different "
+                f"checksum in the folder at {datafile.relative_filepath}. Skipping upload "
+                f"(use --replace_existing to overwrite)."
+            )
+            return None
         else:
             # Upload as a new item
             try:

--- a/openmsistream/girder/girder_upload_stream_processor.py
+++ b/openmsistream/girder/girder_upload_stream_processor.py
@@ -8,6 +8,7 @@ from io import BytesIO
 import girder_client
 import requests
 from requests.adapters import HTTPAdapter
+from requests.exceptions import HTTPError
 from urllib3.util.retry import Retry
 
 from ..data_file_io.actor.data_file_stream_processor import DataFileStreamProcessor
@@ -56,6 +57,47 @@ class GirderClientWithSession(girder_client.GirderClient):
             self.authenticate(apiKey=apiKey)
 
         self._session = session
+
+    def existing_resource(self, datafile, folder_id):
+        try:
+            hashsum = datafile.check_file_hash
+            resp = self.get(f"hashsum/sha512/{hashsum}")
+            resp.raise_for_status()  # if hashsum_download is not installed it will throw 404
+            for fobj in resp:
+                item = self.get(f"item/{fobj['itemId']}")
+                if not item["folderId"] == folder_id:
+                    continue
+                return fobj, item
+        except HTTPError:
+            # fallback to checking for existing file by name
+            for item in self.listItem(folder_id, name=datafile.filename):
+                return next(self.listFile(item["_id"]), None), item
+        return None, None
+
+    def replace_existing_file(self, datafile, file_obj, mimetype=None):
+        if datafile.full_filepath and datafile.full_filepath.is_file():
+            size = datafile.full_filepath.stat().st_size
+            with open(datafile.full_filepath, "rb") as stream:
+                self.uploadFileContents(file_obj["_id"], stream, size)
+        else:
+            data = datafile.bytestring
+            self.uploadFileContents(file_obj["_id"], BytesIO(data), len(data))
+        return {"itemId": file_obj["itemId"]}
+
+    def upload_new_file(self, parent_id, datafile, mimetype=None):
+        if datafile.full_filepath and datafile.full_filepath.is_file():
+            return self.uploadFileToFolder(
+                parent_id, datafile.full_filepath, mimeType=mimetype
+            )
+        # in memory handling
+        data = datafile.bytestring
+        return self.uploadStreamToFolder(
+            parent_id,
+            BytesIO(data),
+            datafile.filename,
+            len(data),
+            mimeType=mimetype,
+        )
 
 
 class GirderUploadStreamProcessor(DataFileStreamProcessor):
@@ -245,78 +287,54 @@ class GirderUploadStreamProcessor(DataFileStreamProcessor):
                     self.logger.error(errmsg, exc_info=exc)
                     return exc
                 parent_id = new_folder_id
-        # Calculate the checksum of the file
-        checksum_hash = self.__get_checksum(datafile).hex()
-        # Check if an item with the same name already exists in the folder
-        existing_item = None
-        for resp in self.girder_client.listItem(parent_id, name=datafile.filename):
-            existing_sha256 = resp.get("meta", {}).get("checksum", {}).get("sha256")
-            if existing_sha256 == checksum_hash:
-                self.logger.warning(
-                    f"WARNING: found an existing Item named {datafile.filename} with the same "
-                    f"checksum in the folder at {datafile.relative_filepath}. Skipping upload."
-                )
-                return None
-            existing_item = resp
-            break
 
+        # Calculate sh256 checksum of the file for backward compatiblity
+        checksum_hash = self.__get_checksum(datafile).hex()
         mimetype, _ = mimetypes.guess_type(datafile.filename)
         mimetype = mimetype or "application/octet-stream"
 
-        # Replace contents of the existing item if --replace_existing is set
-        if existing_item and self.replace_existing:
+        # Check if an item with the same name already exists in the folder
+        existing_file, existing_item = self.girder_client.existing_resource(
+            datafile, parent_id
+        )
+        if existing_item and existing_file:
+            same_file = (existing_file.get("sha512") == datafile.check_file_hash) or (
+                existing_item.get("meta", {}).get("checksum", {}).get("sha256")
+                == checksum_hash
+            )
+            if not (same_file or self.replace_existing):
+                msg = (
+                    f"Found an existing Item named {datafile.filename} in the folder at "
+                    f"{datafile.relative_filepath}, but it has a different checksum than "
+                    "the file being uploaded. "
+                    "(Use --replace_existing to overwrite.)"
+                )
+                self.logger.info(msg)
+                return None
+
             try:
-                file_obj = next(self.girder_client.listFile(existing_item["_id"]), None)
-                if file_obj is None:
-                    raise Exception(
-                        f"No file found under existing item {existing_item['_id']}"
-                    )
-                if datafile.full_filepath and datafile.full_filepath.is_file():
-                    size = datafile.full_filepath.stat().st_size
-                    with open(datafile.full_filepath, "rb") as stream:
-                        self.girder_client.uploadFileContents(
-                            file_obj["_id"], stream, size
-                        )
-                else:
-                    data = datafile.bytestring
-                    self.girder_client.uploadFileContents(
-                        file_obj["_id"], BytesIO(data), len(data)
-                    )
-                upload_obj = {"itemId": existing_item["_id"]}
+                upload_obj = self.girder_client.replace_existing_file(
+                    datafile, existing_file, mimetype=mimetype
+                )
             except Exception as exc:
                 errmsg = (
                     f"ERROR: failed to replace the file at {datafile.relative_filepath}"
                 )
                 self.logger.error(errmsg, exc_info=exc)
                 return exc
-        elif existing_item:
-            self.logger.warning(
-                f"WARNING: found an existing Item named {datafile.filename} with a different "
-                f"checksum in the folder at {datafile.relative_filepath}. Skipping upload "
-                f"(use --replace_existing to overwrite)."
-            )
-            return None
         else:
             # Upload as a new item
             try:
-                if datafile.full_filepath and datafile.full_filepath.is_file():
-                    upload_obj = self.girder_client.uploadFileToFolder(
-                        parent_id, datafile.full_filepath, mimeType=mimetype
-                    )
-                else:
-                    upload_obj = self.girder_client.uploadStreamToFolder(
-                        parent_id,
-                        BytesIO(datafile.bytestring),
-                        datafile.filename,
-                        len(datafile.bytestring),
-                        mimeType=mimetype,
-                    )
+                upload_obj = self.girder_client.upload_new_file(
+                    parent_id, datafile, mimetype=mimetype
+                )
             except Exception as exc:
                 errmsg = (
                     f"ERROR: failed to upload the file at {datafile.relative_filepath}"
                 )
                 self.logger.error(errmsg, exc_info=exc)
                 return exc
+
         # Add metadata to the item that was created for the file
         metadata_dict = self.minimal_metadata_dict.copy()
         metadata_dict["checksum"] = {

--- a/openmsistream/girder/girder_upload_stream_processor.py
+++ b/openmsistream/girder/girder_upload_stream_processor.py
@@ -107,6 +107,7 @@ class GirderUploadStreamProcessor(DataFileStreamProcessor):
         collection_name=None,
         girder_root_folder_path=None,
         metadata=None,
+        replace_existing=False,
         **other_kwargs,
     ):
         super().__init__(config_file, topic_name, **other_kwargs)
@@ -135,6 +136,7 @@ class GirderUploadStreamProcessor(DataFileStreamProcessor):
                 )
                 self.logger.error(errmsg, exc_info=exc, reraise=True)
                 raise ValueError(errmsg) from exc
+        self.replace_existing = replace_existing
         # if a root folder ID was given, just use that
         if girder_root_folder_id:
             self.__root_folder_id = girder_root_folder_id
@@ -245,39 +247,69 @@ class GirderUploadStreamProcessor(DataFileStreamProcessor):
                 parent_id = new_folder_id
         # Calculate the checksum of the file
         checksum_hash = self.__get_checksum(datafile).hex()
-        # Check if a file with the same name and checksum already exists in the folder
+        # Check if an item with the same name already exists in the folder
+        existing_item = None
         for resp in self.girder_client.listItem(parent_id, name=datafile.filename):
             existing_sha256 = resp.get("meta", {}).get("checksum", {}).get("sha256")
             if existing_sha256 == checksum_hash:
-                errmsg = (
+                self.logger.warning(
                     f"WARNING: found an existing Item named {datafile.filename} with the same "
                     f"checksum in the folder at {datafile.relative_filepath}. Skipping upload."
                 )
-                self.logger.warning(errmsg)
-                print(f"File {datafile.filename} already exists with the same checksum")
                 return None
+            existing_item = resp
+            break
 
-        # Upload the file from file on disk or its bytestring if in memory
-        try:
-            mimetype, _ = mimetypes.guess_type(datafile.filename)
-            mimetype = mimetype or "application/octet-stream"
-            if datafile.full_filepath and datafile.full_filepath.is_file():
-                # If the file exists on disk, upload it directly
-                upload_obj = self.girder_client.uploadFileToFolder(
-                    parent_id, datafile.full_filepath, mimeType=mimetype
+        mimetype, _ = mimetypes.guess_type(datafile.filename)
+        mimetype = mimetype or "application/octet-stream"
+
+        # Replace contents of the existing item if --replace_existing is set
+        if existing_item and self.replace_existing:
+            try:
+                file_obj = next(self.girder_client.listFile(existing_item["_id"]), None)
+                if file_obj is None:
+                    raise Exception(
+                        f"No file found under existing item {existing_item['_id']}"
+                    )
+                if datafile.full_filepath and datafile.full_filepath.is_file():
+                    size = datafile.full_filepath.stat().st_size
+                    with open(datafile.full_filepath, "rb") as stream:
+                        self.girder_client.uploadFileContents(
+                            file_obj["_id"], stream, size
+                        )
+                else:
+                    data = datafile.bytestring
+                    self.girder_client.uploadFileContents(
+                        file_obj["_id"], BytesIO(data), len(data)
+                    )
+                upload_obj = {"itemId": existing_item["_id"]}
+            except Exception as exc:
+                errmsg = (
+                    f"ERROR: failed to replace the file at {datafile.relative_filepath}"
                 )
-            else:
-                upload_obj = self.girder_client.uploadStreamToFolder(
-                    parent_id,
-                    BytesIO(datafile.bytestring),
-                    datafile.filename,
-                    len(datafile.bytestring),
-                    mimeType=mimetype,
+                self.logger.error(errmsg, exc_info=exc)
+                return exc
+        else:
+            # Upload as a new item
+            try:
+                if datafile.full_filepath and datafile.full_filepath.is_file():
+                    upload_obj = self.girder_client.uploadFileToFolder(
+                        parent_id, datafile.full_filepath, mimeType=mimetype
+                    )
+                else:
+                    upload_obj = self.girder_client.uploadStreamToFolder(
+                        parent_id,
+                        BytesIO(datafile.bytestring),
+                        datafile.filename,
+                        len(datafile.bytestring),
+                        mimeType=mimetype,
+                    )
+            except Exception as exc:
+                errmsg = (
+                    f"ERROR: failed to upload the file at {datafile.relative_filepath}"
                 )
-        except Exception as exc:
-            errmsg = f"ERROR: failed to upload the file at {datafile.relative_filepath}"
-            self.logger.error(errmsg, exc_info=exc)
-            return exc
+                self.logger.error(errmsg, exc_info=exc)
+                return exc
         # Add metadata to the item that was created for the file
         metadata_dict = self.minimal_metadata_dict.copy()
         metadata_dict["checksum"] = {
@@ -400,6 +432,7 @@ class GirderUploadStreamProcessor(DataFileStreamProcessor):
             "collection_name",
             "girder_root_folder_path",
             "metadata",
+            "replace_existing",
         ]
         return args, superkwargs
 
@@ -417,6 +450,7 @@ class GirderUploadStreamProcessor(DataFileStreamProcessor):
             "collection_name": parsed_args.collection_name,
             "girder_root_folder_path": parsed_args.girder_root_folder_path,
             "metadata": parsed_args.metadata,
+            "replace_existing": parsed_args.replace_existing,
         }
         return args, kwargs
 

--- a/openmsistream/utilities/argument_parsing.py
+++ b/openmsistream/utilities/argument_parsing.py
@@ -340,6 +340,17 @@ class OpenMSIStreamArgumentParser(OpenMSIArgumentParser):
                 ),
             },
         ],
+        "replace_existing": [
+            "optional",
+            {
+                "action": "store_true",
+                "help": (
+                    "If given, files that already exist in Girder with the same name but a "
+                    "different checksum will have their contents replaced in place rather than "
+                    "being skipped. Useful for continuously-updated files such as log CSVs."
+                ),
+            },
+        ],
         "heartbeat_topic_name": [
             "optional",
             {

--- a/test/test_scripts/test_girder_upload_stream_processor.py
+++ b/test/test_scripts/test_girder_upload_stream_processor.py
@@ -582,6 +582,86 @@ def test_girder_with_custom_folder_path(
     [{TOPIC_NAME: {}}],
     indirect=True,
 )
+def test_girder_replace_existing(
+    kafka_topics,
+    girder_instance,
+    stream_processor_helper,
+    upload_file_helper,
+    tmp_path,
+):
+    """Upload a file twice with different content; verify replace_existing=True replaces
+    the Girder item in place rather than creating a duplicate."""
+    api_url = girder_instance["api_url"]
+    api_key = girder_instance["api_key"]
+
+    csv_file = tmp_path / "log.csv"
+
+    # --- v1: one row ---
+    csv_file.write_text("shot,value\n1,100\n")
+    upload_file_helper(csv_file, topic_name=TOPIC_NAME, rootdir=tmp_path)
+    stream_processor_helper["create_stream_processor"](
+        stream_processor_type=GirderUploadStreamProcessor,
+        topic_name=TOPIC_NAME,
+        consumer_group_id=f"pytest_{TOPIC_NAME}_replace",
+        other_init_args=(api_url, api_key),
+        other_init_kwargs={
+            "collection_name": COLLECTION_NAME,
+            "replace_existing": True,
+            "mode": "memory",
+        },
+    )
+    stream_processor_helper["start_stream_processor_thread"]()
+    stream_processor_helper["wait_for_files_to_be_processed"](
+        csv_file.relative_to(tmp_path), timeout_secs=180
+    )
+    stream_processor_helper["reset_stream_processor"]()
+
+    # --- v2: two rows ---
+    csv_file.write_text("shot,value\n1,100\n2,200\n")
+    upload_file_helper(csv_file, topic_name=TOPIC_NAME, rootdir=tmp_path)
+    stream_processor_helper["create_stream_processor"](
+        stream_processor_type=GirderUploadStreamProcessor,
+        topic_name=TOPIC_NAME,
+        consumer_group_id=f"pytest_{TOPIC_NAME}_replace",
+        other_init_args=(api_url, api_key),
+        other_init_kwargs={
+            "collection_name": COLLECTION_NAME,
+            "replace_existing": True,
+            "mode": "memory",
+        },
+    )
+    stream_processor_helper["start_stream_processor_thread"]()
+    stream_processor_helper["wait_for_files_to_be_processed"](
+        csv_file.relative_to(tmp_path), timeout_secs=180
+    )
+
+    girder = girder_client.GirderClient(apiUrl=api_url)
+    girder.authenticate(apiKey=api_key)
+
+    gpath = f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/{TOPIC_NAME}"
+    folder = girder.get("/resource/lookup", parameters={"path": gpath})
+    items = list(girder.listItem(folder["_id"], name=csv_file.name))
+
+    # exactly one item — no duplicate created
+    assert len(items) == 1
+
+    # content matches v2
+    file_obj = next(girder.listFile(items[0]["_id"]))
+    content = b"".join(girder.downloadFileAsIterator(file_obj["_id"]))
+    assert content == b"shot,value\n1,100\n2,200\n"
+
+    girder.delete(f"/item/{items[0]['_id']}")
+
+
+# ------------------------------------------------------------
+
+
+@pytest.mark.kafka
+@pytest.mark.parametrize(
+    "kafka_topics",
+    [{TOPIC_NAME: {}}],
+    indirect=True,
+)
 def test_girder_disk_mode(
     kafka_topics,
     girder_instance,

--- a/test/test_scripts/test_girder_upload_stream_processor.py
+++ b/test/test_scripts/test_girder_upload_stream_processor.py
@@ -1,26 +1,67 @@
+import re
 import json
-import pathlib
-import tempfile
 from hashlib import sha512
+from threading import Lock
 
 import pytest
 import responses
 import girder_client
 
 from openmsistream import GirderUploadStreamProcessor
+from openmsistream.data_file_io.entity.download_data_file import (
+    DownloadDataFileToDisk,
+    DownloadDataFileToMemory,
+)
 from .config import TEST_CONST
-
-# ----------------------------
-# Constants
-# ----------------------------
 
 COLLECTION_NAME = "testing_collection"
 TOPIC_NAME = "test_girder_upload_stream_processor"
 
 
-# ============================================================
-# Helpers
-# ============================================================
+@pytest.fixture(params=["memory", "disk"])
+def mock_datafile(request, tmp_path):
+    mode = request.param
+
+    def _create_datafile(
+        content,
+        filename,
+        subdir_str="",
+        filepath=None,
+    ):
+        """
+        Create a mock DownloadDataFile with the given properties.
+
+        :param content: The file content as bytes
+        :param filename: The filename
+        :param subdir_str: Subdirectory string (empty string for root)
+        :param filepath: Optional custom filepath (defaults to tmp_path/filename)
+        :return: DownloadDataFileToDisk or DownloadDataFileToMemory instance
+        """
+        if filepath is None:
+            filepath = tmp_path / filename
+
+        if mode == "memory":
+            datafile = DownloadDataFileToMemory(filepath)
+            datafile.filename = filename
+            datafile.full_filepath = filepath
+            datafile.subdir_str = subdir_str
+            datafile.n_total_chunks = 1
+            datafile.bytestring = content
+        else:  # disk mode
+            # Ensure parent directory exists
+            filepath.parent.mkdir(parents=True, exist_ok=True)
+            # Write content to disk
+            filepath.write_bytes(content)
+
+            datafile = DownloadDataFileToDisk(filepath)
+            datafile.filename = filename
+            datafile.full_filepath = filepath
+            datafile.subdir_str = subdir_str
+            datafile.n_total_chunks = 1
+
+        return datafile
+
+    return _create_datafile
 
 
 def _produce_single_file(
@@ -55,165 +96,6 @@ def _produce_single_file(
     )
 
     stream_processor_helper["start_stream_processor_thread"]()
-
-
-# ============================================================
-# Tests
-# ============================================================
-
-
-@pytest.mark.kafka
-@pytest.mark.parametrize(
-    "kafka_topics",
-    [{TOPIC_NAME: {}}],
-    indirect=True,
-)
-def test_girder_mimetype(
-    kafka_topics,
-    girder_instance,
-    stream_processor_helper,
-    upload_file_helper,
-):
-    api_url = girder_instance["api_url"]
-    api_key = girder_instance["api_key"]
-
-    with tempfile.NamedTemporaryFile(
-        dir=TEST_CONST.TEST_DATA_DIR_PATH, suffix=".png"
-    ) as mock_png:
-        mock_png.write(b"Pretend to be a PNG")
-        mock_png.flush()
-        png_path = pathlib.Path(mock_png.name)
-
-        _produce_single_file(
-            png_path,
-            topic_name=TOPIC_NAME,
-            api_url=api_url,
-            api_key=api_key,
-            upload_file_helper=upload_file_helper,
-            stream_processor_helper=stream_processor_helper,
-        )
-
-        rel_path = png_path.relative_to(TEST_CONST.TEST_DATA_DIR_PATH)
-        stream_processor_helper["wait_for_files_to_be_processed"](
-            rel_path, timeout_secs=180
-        )
-
-        girder = girder_client.GirderClient(apiUrl=api_url)
-        girder.authenticate(apiKey=api_key)
-
-        gpath = (
-            f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/"
-            f"{TOPIC_NAME}/{rel_path.name}"
-        )
-
-        item = girder.get(
-            "resource/lookup",
-            parameters={"path": gpath},
-        )
-        assert item["_modelType"] == "item"
-
-        fobj = next(girder.listFile(item["_id"]), None)
-        assert fobj is not None
-        assert fobj["_modelType"] == "file"
-        assert fobj["mimeType"] == "image/png"
-
-        girder.delete(f"/item/{item['_id']}")
-
-
-# ------------------------------------------------------------
-
-
-@pytest.mark.kafka
-@responses.activate
-@pytest.mark.parametrize(
-    "kafka_topics",
-    [{TOPIC_NAME: {}}],
-    indirect=True,
-)
-def test_girder_handle_timeout(
-    kafka_topics,
-    girder_instance,
-    stream_processor_helper,
-    upload_file_helper,
-):
-    api_url = girder_instance["api_url"]
-    api_key = girder_instance["api_key"]
-
-    responses.add_passthru(api_url)
-
-    # First call to /file should return 502 though
-    responses.add(
-        responses.POST,
-        f"{api_url}/file",
-        status=502,
-    )
-
-    # but work after retry
-    responses.add(responses.PassthroughResponse(responses.POST, f"{api_url}/file"))
-
-    _produce_single_file(
-        TEST_CONST.TEST_DATA_FILE_2_PATH,
-        topic_name=TOPIC_NAME,
-        api_url=api_url,
-        api_key=api_key,
-        upload_file_helper=upload_file_helper,
-        stream_processor_helper=stream_processor_helper,
-    )
-
-    rel = TEST_CONST.TEST_DATA_FILE_2_PATH.relative_to(TEST_CONST.TEST_DATA_DIR_PATH)
-
-    stream_processor_helper["wait_for_files_to_be_processed"](rel, timeout_secs=180)
-
-
-# ------------------------------------------------------------
-
-
-@pytest.mark.kafka
-@pytest.mark.parametrize(
-    "kafka_topics",
-    [{TOPIC_NAME: {}}],
-    indirect=True,
-)
-def test_girder_repeated_upload(
-    kafka_topics,
-    girder_instance,
-    stream_processor_helper,
-    upload_file_helper,
-):
-    api_url = girder_instance["api_url"]
-    api_key = girder_instance["api_key"]
-
-    for mode in ["disk", "memory"]:
-        _produce_single_file(
-            TEST_CONST.TEST_DATA_FILE_2_PATH,
-            topic_name=TOPIC_NAME,
-            api_url=api_url,
-            api_key=api_key,
-            upload_file_helper=upload_file_helper,
-            stream_processor_helper=stream_processor_helper,
-            mode=mode,
-        )
-
-        rel = TEST_CONST.TEST_DATA_FILE_2_PATH.relative_to(TEST_CONST.TEST_DATA_DIR_PATH)
-
-        stream_processor_helper["wait_for_files_to_be_processed"](rel, timeout_secs=180)
-
-        stream_processor_helper["reset_stream_processor"]()
-
-    girder = girder_client.GirderClient(apiUrl=api_url)
-    girder.authenticate(apiKey=api_key)
-
-    gpath = f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/{TOPIC_NAME}"
-    folder = girder.get(
-        "/resource/lookup",
-        parameters={"path": gpath},
-    )
-    assert folder
-    items = girder.listItem(folder["_id"])
-    assert len(list(items)) == 1
-
-
-# ------------------------------------------------------------
 
 
 @pytest.mark.kafka
@@ -280,58 +162,32 @@ def test_girder_upload_stream_processor_kafka(
     girder.delete(f"/item/{item['_id']}")
 
 
-# ------------------------------------------------------------
-
-
 @pytest.mark.kafka
-@pytest.mark.parametrize(
-    "kafka_topics",
-    [{TOPIC_NAME: {}}],
-    indirect=True,
-)
-def test_girder_invalid_metadata_json(
-    kafka_topics,
-    girder_instance,
-    stream_processor_helper,
-    upload_file_helper,
-):
+def test_girder_invalid_metadata_json(girder_instance, apply_kafka_env):
     """Test handling of invalid JSON metadata."""
     api_url = girder_instance["api_url"]
     api_key = girder_instance["api_key"]
 
     # This should fail when trying to parse invalid JSON metadata
     with pytest.raises(Exception) as exc_info:
-        stream_processor_helper["create_stream_processor"](
-            stream_processor_type=GirderUploadStreamProcessor,
+        GirderUploadStreamProcessor(
+            api_url,
+            api_key,
+            config_file=TEST_CONST.TEST_CFG_FILE_PATH,
             topic_name=TOPIC_NAME,
             consumer_group_id=f"pytest_{TOPIC_NAME}",
-            other_init_args=(api_url, api_key),
-            other_init_kwargs={
-                "collection_name": COLLECTION_NAME,
-                "metadata": "this is not valid JSON",
-                "mode": "memory",
-            },
+            collection_name=COLLECTION_NAME,
+            metadata="this is not valid JSON",
+            mode="memory",
         )
 
     # Check that it's a JSON decode error
     assert "Expecting value" in str(exc_info.value)
 
 
-# ------------------------------------------------------------
-
-
 @pytest.mark.kafka
 @responses.activate
-@pytest.mark.parametrize(
-    "kafka_topics",
-    [{TOPIC_NAME: {}}],
-    indirect=True,
-)
-def test_girder_authentication_failure(
-    kafka_topics,
-    girder_instance,
-    stream_processor_helper,
-):
+def test_girder_authentication_failure(girder_instance, apply_kafka_env):
     """Test handling of Girder authentication failure."""
     api_url = girder_instance["api_url"]
 
@@ -343,20 +199,17 @@ def test_girder_authentication_failure(
         json={"message": "Invalid API key"},
     )
 
-    # This should fail when trying to authenticate
     with pytest.raises(Exception) as exc_info:
-        stream_processor_helper["create_stream_processor"](
-            stream_processor_type=GirderUploadStreamProcessor,
+        GirderUploadStreamProcessor(
+            api_url,
+            "invalid_api_key",
+            config_file=TEST_CONST.TEST_CFG_FILE_PATH,
             topic_name=TOPIC_NAME,
             consumer_group_id=f"pytest_{TOPIC_NAME}",
-            other_init_args=(api_url, "invalid_api_key"),
-            other_init_kwargs={
-                "collection_name": COLLECTION_NAME,
-                "mode": "memory",
-            },
+            collection_name=COLLECTION_NAME,
+            mode="memory",
         )
 
-    # The error could be about authentication or connection refused
     assert "authenticate" in str(exc_info.value).lower() or "401" in str(exc_info.value)
 
 
@@ -364,336 +217,373 @@ def test_girder_authentication_failure(
 
 
 @pytest.mark.kafka
-@pytest.mark.parametrize(
-    "kafka_topics",
-    [{TOPIC_NAME: {}}],
-    indirect=True,
-)
-def test_girder_with_root_folder_id(
-    kafka_topics,
-    girder_instance,
-    stream_processor_helper,
-    upload_file_helper,
+def test_girder_upload_simple_file(
+    mock_datafile, girder_instance, tmp_path, apply_kafka_env
 ):
-    """Test using a specific root folder ID instead of collection name."""
+    """Test uploading a simple file using direct _process_downloaded_data_file call."""
     api_url = girder_instance["api_url"]
     api_key = girder_instance["api_key"]
 
-    # First, create a folder to use
-    girder = girder_client.GirderClient(apiUrl=api_url)
-    girder.authenticate(apiKey=api_key)
-
-    # Get collection
-    coll_id = None
-    for c in girder.listCollection():
-        if c["name"] == COLLECTION_NAME:
-            coll_id = c["_id"]
-            break
-
-    if not coll_id:
-        coll = girder.createCollection(COLLECTION_NAME, public=True)
-        coll_id = coll["_id"]
-
-    # Create a test folder
-    test_folder = girder.createFolder(
-        coll_id,
-        "test_root_folder",
-        parentType="collection",
-        reuseExisting=True,
+    # Create a processor instance
+    processor = GirderUploadStreamProcessor(
+        api_url,
+        api_key,
+        config_file=TEST_CONST.TEST_CFG_FILE_PATH,
+        topic_name=TOPIC_NAME,
+        collection_name=COLLECTION_NAME,
     )
 
-    try:
-        upload_file_helper(
-            TEST_CONST.TEST_DATA_FILE_2_PATH,
-            topic_name=TOPIC_NAME,
-            rootdir=TEST_CONST.TEST_DATA_DIR_PATH,
-        )
+    # Create a mock datafile
+    content = b"Test file content"
+    datafile = mock_datafile(
+        content=content,
+        filename="test_file.txt",
+        subdir_str="",
+    )
 
-        stream_processor_helper["create_stream_processor"](
-            stream_processor_type=GirderUploadStreamProcessor,
-            topic_name=TOPIC_NAME,
-            consumer_group_id=f"pytest_{TOPIC_NAME}",
-            other_init_args=(api_url, api_key),
-            other_init_kwargs={
-                "girder_root_folder_id": test_folder["_id"],
-                "mode": "memory",
-            },
-        )
+    result = processor._process_downloaded_data_file(datafile, Lock())
 
-        stream_processor_helper["start_stream_processor_thread"]()
+    # Should succeed (return None)
+    assert result is None
 
-        rel = TEST_CONST.TEST_DATA_FILE_2_PATH.relative_to(TEST_CONST.TEST_DATA_DIR_PATH)
-        stream_processor_helper["wait_for_files_to_be_processed"](rel, timeout_secs=180)
+    # Verify the file was uploaded to Girder
+    gc = girder_client.GirderClient(apiUrl=api_url)
+    gc.authenticate(apiKey=api_key)
 
-        # Verify the file was uploaded to the correct folder
-        items = list(girder.listItem(test_folder["_id"], name=rel.name))
-        assert len(items) > 0
+    gpath = f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/{TOPIC_NAME}/test_file.txt"
+    item = gc.get("resource/lookup", parameters={"path": gpath})
+    assert item["_modelType"] == "item"
 
-        # Clean up
-        for item in items:
-            girder.delete(f"/item/{item['_id']}")
-    finally:
-        girder.delete(f"/folder/{test_folder['_id']}")
+    # Verify content
+    file_id = next(f["_id"] for f in gc.listFile(item["_id"]))
+    downloaded_content = b""
+    for chunk in gc.downloadFileAsIterator(file_id):
+        downloaded_content += chunk
+    assert downloaded_content == content
 
-
-# ------------------------------------------------------------
+    # Cleanup
+    gc.delete(f"/item/{item['_id']}")
 
 
 @pytest.mark.kafka
-@pytest.mark.parametrize(
-    "kafka_topics",
-    [{TOPIC_NAME: {}}],
-    indirect=True,
-)
-def test_girder_nested_subdirectories(
-    kafka_topics,
-    girder_instance,
-    stream_processor_helper,
-    upload_file_helper,
+def test_girder_upload_with_subdirectories(
+    mock_datafile, girder_instance, tmp_path, apply_kafka_env
 ):
-    """Test uploading files with nested subdirectory structure."""
+    """Test uploading files with subdirectories using direct method call."""
     api_url = girder_instance["api_url"]
     api_key = girder_instance["api_key"]
 
-    # Create a nested directory structure
-    nested_dir = TEST_CONST.TEST_DATA_DIR_PATH / "level1" / "level2" / "level3"
-    nested_dir.mkdir(parents=True, exist_ok=True)
-
-    test_file = nested_dir / "nested_test.txt"
-    test_file.write_text("Nested file content")
-
-    try:
-        upload_file_helper(
-            test_file,
-            topic_name=TOPIC_NAME,
-            rootdir=TEST_CONST.TEST_DATA_DIR_PATH,
-        )
-
-        stream_processor_helper["create_stream_processor"](
-            stream_processor_type=GirderUploadStreamProcessor,
-            topic_name=TOPIC_NAME,
-            consumer_group_id=f"pytest_{TOPIC_NAME}",
-            other_init_args=(api_url, api_key),
-            other_init_kwargs={
-                "collection_name": COLLECTION_NAME,
-                "metadata": json.dumps({"nested": "true"}),
-                "mode": "memory",
-            },
-        )
-
-        stream_processor_helper["start_stream_processor_thread"]()
-
-        rel_path = test_file.relative_to(TEST_CONST.TEST_DATA_DIR_PATH)
-        stream_processor_helper["wait_for_files_to_be_processed"](
-            rel_path, timeout_secs=180
-        )
-
-        girder = girder_client.GirderClient(apiUrl=api_url)
-        girder.authenticate(apiKey=api_key)
-
-        gpath = (
-            f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/"
-            f"{TOPIC_NAME}/level1/level2/level3/{test_file.name}"
-        )
-
-        item = girder.get(
-            "resource/lookup",
-            parameters={"path": gpath},
-        )
-        assert item["_modelType"] == "item"
-        assert item["meta"]["nested"] == "true"
-
-        girder.delete(f"/item/{item['_id']}")
-    finally:
-        test_file.unlink(missing_ok=True)
-        # Clean up nested directories
-        for parent in [nested_dir, nested_dir.parent, nested_dir.parent.parent]:
-            try:
-                parent.rmdir()
-            except (OSError, FileNotFoundError):
-                pass
-
-
-# ------------------------------------------------------------
-
-
-@pytest.mark.kafka
-@pytest.mark.parametrize(
-    "kafka_topics",
-    [{TOPIC_NAME: {}}],
-    indirect=True,
-)
-def test_girder_with_custom_folder_path(
-    kafka_topics,
-    girder_instance,
-    stream_processor_helper,
-    upload_file_helper,
-):
-    """Test uploading files with a custom girder root folder path."""
-    api_url = girder_instance["api_url"]
-    api_key = girder_instance["api_key"]
-
-    upload_file_helper(
-        TEST_CONST.TEST_DATA_FILE_2_PATH,
+    processor = GirderUploadStreamProcessor(
+        api_url,
+        api_key,
+        config_file=TEST_CONST.TEST_CFG_FILE_PATH,
         topic_name=TOPIC_NAME,
-        rootdir=TEST_CONST.TEST_DATA_DIR_PATH,
+        collection_name=COLLECTION_NAME,
     )
 
-    stream_processor_helper["create_stream_processor"](
-        stream_processor_type=GirderUploadStreamProcessor,
-        topic_name=TOPIC_NAME,
-        consumer_group_id=f"pytest_{TOPIC_NAME}",
-        other_init_args=(api_url, api_key),
-        other_init_kwargs={
-            "collection_name": COLLECTION_NAME,
-            "girder_root_folder_path": f"{COLLECTION_NAME}/custom_path/{TOPIC_NAME}",
-            "mode": "memory",
-        },
+    content = b"Nested file content"
+    datafile = mock_datafile(
+        content=content,
+        filename="nested.txt",
+        subdir_str="level1/level2/level3",
     )
 
-    stream_processor_helper["start_stream_processor_thread"]()
+    result = processor._process_downloaded_data_file(datafile, Lock())
+    assert result is None
 
-    rel = TEST_CONST.TEST_DATA_FILE_2_PATH.relative_to(TEST_CONST.TEST_DATA_DIR_PATH)
-    stream_processor_helper["wait_for_files_to_be_processed"](rel, timeout_secs=180)
-
-    girder = girder_client.GirderClient(apiUrl=api_url)
-    girder.authenticate(apiKey=api_key)
+    # Verify the nested folder structure was created
+    gc = girder_client.GirderClient(apiUrl=api_url)
+    gc.authenticate(apiKey=api_key)
 
     gpath = (
-        f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/custom_path/"
-        f"{TOPIC_NAME}/{rel.name}"
+        f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/"
+        f"{TOPIC_NAME}/level1/level2/level3/nested.txt"
     )
-
-    item = girder.get(
-        "resource/lookup",
-        parameters={"path": gpath},
-    )
+    item = gc.get("resource/lookup", parameters={"path": gpath})
     assert item["_modelType"] == "item"
 
-    girder.delete(f"/item/{item['_id']}")
-
-
-# ------------------------------------------------------------
+    # Cleanup
+    gc.delete(f"/item/{item['_id']}")
 
 
 @pytest.mark.kafka
-@pytest.mark.parametrize(
-    "kafka_topics",
-    [{TOPIC_NAME: {}}],
-    indirect=True,
-)
+def test_girder_upload_mimetype(
+    mock_datafile, girder_instance, tmp_path, apply_kafka_env
+):
+    """Test that MIME types are correctly detected."""
+    api_url = girder_instance["api_url"]
+    api_key = girder_instance["api_key"]
+
+    processor = GirderUploadStreamProcessor(
+        api_url,
+        api_key,
+        config_file=TEST_CONST.TEST_CFG_FILE_PATH,
+        topic_name=TOPIC_NAME,
+        collection_name=COLLECTION_NAME,
+    )
+
+    # Create a PNG file
+    content = b"Fake PNG content"
+    datafile = mock_datafile(
+        content=content,
+        filename="test_image.png",
+        subdir_str="",
+    )
+
+    result = processor._process_downloaded_data_file(datafile, Lock())
+    assert result is None
+
+    gc = girder_client.GirderClient(apiUrl=api_url)
+    gc.authenticate(apiKey=api_key)
+
+    gpath = f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/{TOPIC_NAME}/test_image.png"
+    item = gc.get("resource/lookup", parameters={"path": gpath})
+
+    file_obj = next(gc.listFile(item["_id"]))
+    assert file_obj["mimeType"] == "image/png"
+
+    gc.delete(f"/item/{item['_id']}")
+
+
+@pytest.mark.kafka
+@responses.activate
 def test_girder_replace_existing(
-    kafka_topics,
-    girder_instance,
-    stream_processor_helper,
-    upload_file_helper,
-    tmp_path,
+    mock_datafile, girder_instance, tmp_path, apply_kafka_env, caplog
 ):
-    """Upload a file twice with different content; verify replace_existing=True replaces
-    the Girder item in place rather than creating a duplicate."""
+    """Test replace_existing flag using direct method calls."""
     api_url = girder_instance["api_url"]
     api_key = girder_instance["api_key"]
+    responses.add_passthru(api_url)  # Allow real requests to Girder
 
-    csv_file = tmp_path / "log.csv"
-
-    # --- v1: one row ---
-    csv_file.write_text("shot,value\n1,100\n")
-    upload_file_helper(csv_file, topic_name=TOPIC_NAME, rootdir=tmp_path)
-    stream_processor_helper["create_stream_processor"](
-        stream_processor_type=GirderUploadStreamProcessor,
+    # First upload without replace_existing
+    processor1 = GirderUploadStreamProcessor(
+        api_url,
+        api_key,
+        config_file=TEST_CONST.TEST_CFG_FILE_PATH,
         topic_name=TOPIC_NAME,
-        consumer_group_id=f"pytest_{TOPIC_NAME}_replace",
-        other_init_args=(api_url, api_key),
-        other_init_kwargs={
-            "collection_name": COLLECTION_NAME,
-            "replace_existing": True,
-            "mode": "memory",
-        },
+        collection_name=COLLECTION_NAME,
+        replace_existing=False,
     )
-    stream_processor_helper["start_stream_processor_thread"]()
-    stream_processor_helper["wait_for_files_to_be_processed"](
-        csv_file.relative_to(tmp_path), timeout_secs=180
-    )
-    stream_processor_helper["reset_stream_processor"]()
 
-    # --- v2: two rows ---
-    csv_file.write_text("shot,value\n1,100\n2,200\n")
-    upload_file_helper(csv_file, topic_name=TOPIC_NAME, rootdir=tmp_path)
-    stream_processor_helper["create_stream_processor"](
-        stream_processor_type=GirderUploadStreamProcessor,
+    content_v1 = b"Version 1 content"
+    datafile1 = mock_datafile(
+        content=content_v1,
+        filename="versioned.txt",
+        subdir_str="",
+    )
+
+    result = processor1._process_downloaded_data_file(datafile1, Lock())
+    assert result is None
+
+    # Try to upload again without replace - should skip
+    content_v2 = b"Version 2 content (different)"
+    datafile2 = mock_datafile(
+        content=content_v2,
+        filename="versioned.txt",
+        subdir_str="",
+    )
+
+    result = processor1._process_downloaded_data_file(datafile2, Lock())
+    assert result is None  # Should succeed but skip upload
+
+    # Verify content is still v1
+    gc = girder_client.GirderClient(apiUrl=api_url)
+    gc.authenticate(apiKey=api_key)
+
+    gpath = f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/{TOPIC_NAME}/versioned.txt"
+    item = gc.get("resource/lookup", parameters={"path": gpath})
+    file_id = next(f["_id"] for f in gc.listFile(item["_id"]))
+
+    downloaded = b""
+    for chunk in gc.downloadFileAsIterator(file_id):
+        downloaded += chunk
+    assert downloaded == content_v1  # Still version 1
+
+    # Now upload with replace_existing=True
+    processor2 = GirderUploadStreamProcessor(
+        api_url,
+        api_key,
+        config_file=TEST_CONST.TEST_CFG_FILE_PATH,
         topic_name=TOPIC_NAME,
-        consumer_group_id=f"pytest_{TOPIC_NAME}_replace",
-        other_init_args=(api_url, api_key),
-        other_init_kwargs={
-            "collection_name": COLLECTION_NAME,
-            "replace_existing": True,
-            "mode": "memory",
-        },
-    )
-    stream_processor_helper["start_stream_processor_thread"]()
-    stream_processor_helper["wait_for_files_to_be_processed"](
-        csv_file.relative_to(tmp_path), timeout_secs=180
+        collection_name=COLLECTION_NAME,
+        replace_existing=True,
     )
 
-    girder = girder_client.GirderClient(apiUrl=api_url)
-    girder.authenticate(apiKey=api_key)
+    datafile3 = mock_datafile(
+        content=content_v2,
+        filename="versioned.txt",
+        subdir_str="",
+    )
 
-    gpath = f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/{TOPIC_NAME}"
-    folder = girder.get("/resource/lookup", parameters={"path": gpath})
-    items = list(girder.listItem(folder["_id"], name=csv_file.name))
+    # fail first
+    responses.add(
+        responses.PUT,
+        f"{api_url}/file/{file_id}/contents",
+        status=400,
+    )
+    with caplog.at_level("ERROR"):
+        result = processor2._process_downloaded_data_file(datafile3, Lock())
+        assert "ERROR: failed to replace the file at" in caplog.text
+        assert result is not None
+        assert isinstance(result, Exception)
 
-    # exactly one item — no duplicate created
-    assert len(items) == 1
+    responses.reset()  # Clear previous mock
+    responses.add_passthru(api_url)  # Allow real requests again
+    result = processor2._process_downloaded_data_file(datafile3, Lock())
+    assert result is None
 
-    # content matches v2
-    file_obj = next(girder.listFile(items[0]["_id"]))
-    content = b"".join(girder.downloadFileAsIterator(file_obj["_id"]))
-    assert content == b"shot,value\n1,100\n2,200\n"
+    # Verify content is now v2
+    item = gc.get("resource/lookup", parameters={"path": gpath})
+    file_id = next(f["_id"] for f in gc.listFile(item["_id"]))
 
-    girder.delete(f"/item/{items[0]['_id']}")
+    downloaded = b""
+    for chunk in gc.downloadFileAsIterator(file_id):
+        downloaded += chunk
+    assert downloaded == content_v2  # Now version 2
 
-
-# ------------------------------------------------------------
+    gc.delete(f"/item/{item['_id']}")
 
 
 @pytest.mark.kafka
-@pytest.mark.parametrize(
-    "kafka_topics",
-    [{TOPIC_NAME: {}}],
-    indirect=True,
-)
-def test_girder_disk_mode(
-    kafka_topics,
-    girder_instance,
-    stream_processor_helper,
-    upload_file_helper,
+@responses.activate
+def test_girder_upload_failure_direct(
+    mock_datafile, girder_instance, tmp_path, apply_kafka_env, caplog
 ):
-    """Test file upload in disk mode (as opposed to memory mode)."""
+    """Test error handling when upload fails."""
     api_url = girder_instance["api_url"]
     api_key = girder_instance["api_key"]
 
-    _produce_single_file(
-        TEST_CONST.TEST_DATA_FILE_2_PATH,
+    # Mock a failure
+    responses.add_passthru(api_url)
+    responses.add(
+        responses.POST,
+        f"{api_url}/file",
+        status=500,
+        json={"message": "Server error"},
+    )
+
+    processor = GirderUploadStreamProcessor(
+        api_url,
+        api_key,
+        config_file=TEST_CONST.TEST_CFG_FILE_PATH,
         topic_name=TOPIC_NAME,
-        api_url=api_url,
-        api_key=api_key,
-        upload_file_helper=upload_file_helper,
-        stream_processor_helper=stream_processor_helper,
-        mode="disk",
+        collection_name=COLLECTION_NAME,
     )
 
-    rel = TEST_CONST.TEST_DATA_FILE_2_PATH.relative_to(TEST_CONST.TEST_DATA_DIR_PATH)
-
-    stream_processor_helper["wait_for_files_to_be_processed"](rel, timeout_secs=180)
-
-    girder = girder_client.GirderClient(apiUrl=api_url)
-    girder.authenticate(apiKey=api_key)
-
-    gpath = f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/{TOPIC_NAME}/{rel.name}"
-    item = girder.get(
-        "resource/lookup",
-        parameters={"path": gpath},
+    datafile = mock_datafile(
+        content=b"Content",
+        filename="fail.txt",
+        subdir_str="",
     )
-    assert item["_modelType"] == "item"
 
-    girder.delete(f"/item/{item['_id']}")
+    with caplog.at_level("ERROR"):
+        result = processor._process_downloaded_data_file(datafile, Lock())
+        assert "failed to upload the file at" in caplog.text
+        assert result is not None
+        assert isinstance(result, Exception)
+
+
+@pytest.mark.kafka
+@responses.activate
+def test_girder_retry_on_timeout(
+    mock_datafile, girder_instance, tmp_path, apply_kafka_env
+):
+    """Test that transient failures are retried."""
+    api_url = girder_instance["api_url"]
+    api_key = girder_instance["api_key"]
+
+    responses.add_passthru(api_url)
+
+    # First call fails with 502
+    responses.add(
+        responses.POST,
+        f"{api_url}/file",
+        status=502,
+    )
+
+    # Second call succeeds (passthrough)
+    responses.add(responses.PassthroughResponse(responses.POST, f"{api_url}/file"))
+
+    processor = GirderUploadStreamProcessor(
+        api_url,
+        api_key,
+        config_file=TEST_CONST.TEST_CFG_FILE_PATH,
+        topic_name=TOPIC_NAME,
+        collection_name=COLLECTION_NAME,
+    )
+
+    datafile = mock_datafile(
+        content=b"Retry test content",
+        filename="retry.txt",
+        subdir_str="",
+    )
+
+    result = processor._process_downloaded_data_file(datafile, Lock())
+
+    # Should succeed after retry
+    assert result is None
+
+    # Verify file was uploaded
+    gc = girder_client.GirderClient(apiUrl=api_url)
+    gc.authenticate(apiKey=api_key)
+
+    gpath = f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/{TOPIC_NAME}/retry.txt"
+    item = gc.get("resource/lookup", parameters={"path": gpath})
+    assert item is not None
+
+    gc.delete(f"/item/{item['_id']}")
+
+
+@pytest.mark.kafka
+@responses.activate
+def test_girder_odd_failures(
+    mock_datafile, girder_instance, tmp_path, apply_kafka_env, caplog
+):
+    """Test handling of unexpected exceptions."""
+    api_url = girder_instance["api_url"]
+    api_key = girder_instance["api_key"]
+    responses.add_passthru(api_url)
+    gc = girder_client.GirderClient(apiUrl=api_url)
+    gc.authenticate(apiKey=api_key)
+    # Mock an unexpected exception (e.g. connection error)
+    responses.add(responses.PUT, re.compile(f"{api_url}/item/.*/metadata"), status=400)
+
+    processor = GirderUploadStreamProcessor(
+        api_url,
+        api_key,
+        config_file=TEST_CONST.TEST_CFG_FILE_PATH,
+        topic_name=TOPIC_NAME,
+        collection_name=COLLECTION_NAME,
+    )
+
+    datafile = mock_datafile(
+        content=b"Odd failure test",
+        filename="odd_failure.txt",
+        subdir_str="test_folder",
+    )
+
+    with caplog.at_level("ERROR"):
+        result = processor._process_downloaded_data_file(datafile, Lock())
+        assert "failed to set metadata" in caplog.text
+        assert result is not None
+        assert isinstance(result, Exception)
+
+    responses.reset()  # Clear previous mock
+    responses.add_passthru(api_url)
+    gpath = (
+        f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/"
+        f"{TOPIC_NAME}/test_folder/odd_failure.txt"
+    )
+    item = gc.get("resource/lookup", parameters={"path": gpath})
+    assert item is not None
+    gc.delete(f"/item/{item['_id']}")
+
+    # fail to create / get root folder
+    responses.add(responses.POST, re.compile(f"{api_url}/folder"), status=400)
+    with caplog.at_level("ERROR"):
+        result = processor._process_downloaded_data_file(datafile, Lock())
+        assert "failed to create the 'test_folder' folder" in caplog.text
+        assert result is not None
+        assert isinstance(result, Exception)
+    responses.reset()
+    responses.add_passthru(api_url)


### PR DESCRIPTION
Adds a --replace_existing flag to GirderUploadStreamProcessor. When set, files already in Girder with the same name but different checksum are replaced in place instead of skipped. Logs warning if such item is found but replace_existing is set to false. Useful for continuously-updated files like shot log CSVs. 

Includes a basic test with a csv that checks only one file exists, and that its checksum is the same as the last version of the file.