### PR TITLE
Handle str using delimiter in DataclassTable. Fixes #79

### DIFF
--- a/openmsistream/utilities/dataclass_table.py
+++ b/openmsistream/utilities/dataclass_table.py
@@ -353,9 +353,11 @@ class DataclassTableBase(LogOwner, ABC):
         Return the dataclass instance for a given csv file line string
         """
         args = []
-        line_args = next(
-            csv.reader(StringIO(line.strip()), delimiter=self.DELIMITER), None
-        )
+        try:
+            line_args = next(csv.reader(StringIO(line.strip()), delimiter=self.DELIMITER))
+        except StopIteration:
+            errmsg = f"ERROR: failed to parse line from csv file: '{line}'!"
+            self.logger.error(errmsg, exc_type=RuntimeError)
         for attrtype, attrstr in zip(self.__field_types, line_args):
             args.append(self.__get_attribute_from_str(attrstr, attrtype))
         return self.__dataclass_type(*args)
@@ -383,7 +385,7 @@ class DataclassTableBase(LogOwner, ABC):
         if attrtype == pathlib.Path:
             return pathlib.Path(attrstr[1:-1])
         # strings have extra quotes on either end
-        if attrtype == str:
+        if attrtype is str:
             return attrtype(attrstr[1:-1])
         # int, float, complex, and bool can all be directly re-casted
         if attrtype in (int, float, complex, bool):

--- a/openmsistream/utilities/dataclass_table.py
+++ b/openmsistream/utilities/dataclass_table.py
@@ -6,6 +6,7 @@ dataclass objects serialized to/deseralized from a corresponding CSV file in an 
 
 # imports
 import copy
+import csv
 import datetime
 import functools
 import os
@@ -14,6 +15,7 @@ import time
 import typing
 from abc import ABC
 from dataclasses import fields, is_dataclass
+from io import StringIO
 from threading import RLock
 
 import methodtools
@@ -336,21 +338,25 @@ class DataclassTableBase(LogOwner, ABC):
                 f'ERROR: "{obj}" is mismatched to type {self.__dataclass_type}!',
                 exc_type=TypeError,
             )
-        return self.DELIMETER.join(
+        line = StringIO()
+        writer = csv.writer(line, delimiter=self.DELIMETER, quoting=csv.QUOTE_MINIMAL)
+        writer.writerow(
             [
                 self.__get_str_from_attribute(getattr(obj, fname), ftype)
                 for fname, ftype in zip(self.__field_names, self.__field_types)
             ]
         )
+        return line.getvalue().strip()
 
     def __obj_from_line(self, line):
         """
         Return the dataclass instance for a given csv file line string
         """
         args = []
-        for attrtype, attrstr in zip(
-            self.__field_types, (line.strip().split(self.DELIMETER))
-        ):
+        line_args = next(
+            csv.reader(StringIO(line.strip()), delimiter=self.DELIMETER), None
+        )
+        for attrtype, attrstr in zip(self.__field_types, line_args):
             args.append(self.__get_attribute_from_str(attrstr, attrtype))
         return self.__dataclass_type(*args)
 

--- a/openmsistream/utilities/dataclass_table.py
+++ b/openmsistream/utilities/dataclass_table.py
@@ -58,7 +58,7 @@ class DataclassTableBase(LogOwner, ABC):
 
     #################### CONSTANTS ####################
 
-    DELIMETER = ";"  # can't use a comma or containers would display incorrectly
+    DELIMITER = ";"  # can't use a comma or containers would display incorrectly
     DATETIME_FORMAT = "%a %b %d, %Y at %H:%M:%S"
     # only update the .csv file automatically every 5 seconds to make updates less expensive
     UPDATE_FILE_EVERY = 5
@@ -223,9 +223,9 @@ class DataclassTableBase(LogOwner, ABC):
         header_line = ""
         # add an extra line when running on Windows to seamlessly open the file in Excel
         if os.name == "nt":
-            header_line += f"sep={self.DELIMETER}\n"
+            header_line += f"sep={self.DELIMITER}\n"
         for fieldname in self.__field_names:
-            header_line += f"{fieldname}{self.DELIMETER}"
+            header_line += f"{fieldname}{self.DELIMITER}"
         return header_line[:-1]
 
     @property
@@ -339,7 +339,7 @@ class DataclassTableBase(LogOwner, ABC):
                 exc_type=TypeError,
             )
         line = StringIO()
-        writer = csv.writer(line, delimiter=self.DELIMETER, quoting=csv.QUOTE_MINIMAL)
+        writer = csv.writer(line, delimiter=self.DELIMITER, quoting=csv.QUOTE_MINIMAL)
         writer.writerow(
             [
                 self.__get_str_from_attribute(getattr(obj, fname), ftype)
@@ -354,7 +354,7 @@ class DataclassTableBase(LogOwner, ABC):
         """
         args = []
         line_args = next(
-            csv.reader(StringIO(line.strip()), delimiter=self.DELIMETER), None
+            csv.reader(StringIO(line.strip()), delimiter=self.DELIMITER), None
         )
         for attrtype, attrstr in zip(self.__field_types, line_args):
             args.append(self.__get_attribute_from_str(attrstr, attrtype))

--- a/test/test_scripts/test_dataclass_table.py
+++ b/test/test_scripts/test_dataclass_table.py
@@ -20,6 +20,7 @@ class TableLineForTesting:
     tuple_floats_field: Tuple[float]
     path_field: pathlib.Path
     timestamp_field: datetime.datetime
+    weird_field: str
 
 
 def test_dataclass_table_functions(output_dir, logger):
@@ -35,6 +36,7 @@ def test_dataclass_table_functions(output_dir, logger):
         (6.7, 8.9),
         pathlib.Path(__file__),
         datetime.datetime.now(),
+        "asdf;foo",
     )
     entry_2 = TableLineForTesting(
         "test",
@@ -47,6 +49,7 @@ def test_dataclass_table_functions(output_dir, logger):
         (20.21, 22.23),
         pathlib.Path(__file__).parent,
         datetime.datetime.now(),
+        "\tC:\\Path\\With\\Tab\\and,commas.txt",
     )
     entry_3 = TableLineForTesting(
         "test",
@@ -59,6 +62,7 @@ def test_dataclass_table_functions(output_dir, logger):
         (72.0, 84.6),
         pathlib.Path(__file__).parent.parent,
         datetime.datetime.now(),
+        r"C:\Users\Name\Documents\Report.pdf",
     )
 
     entry_1_addr = hex(id(entry_1))
@@ -118,6 +122,9 @@ def test_dataclass_table_functions(output_dir, logger):
     assert len(test_table.obj_addresses_by_key_attr("str_field")["test"]) == 3
 
     assert len(test_table.obj_addresses_by_key_attr("int_field")) == 3
+    assert list(test_table.obj_addresses_by_key_attr("weird_field").keys()) == [
+        _.weird_field for _ in [entry_1, entry_2, entry_3]
+    ]
 
     # ---- modify entry_2 ----
     test_table.set_entry_attrs(entry_2_addr, str_field="testing")

--- a/test/test_scripts/test_dataclass_table.py
+++ b/test/test_scripts/test_dataclass_table.py
@@ -139,3 +139,16 @@ def test_dataclass_table_functions(output_dir, logger):
     assert entry_2_addr in by_str_field["testing"]
 
     test_table.dump_to_file()
+
+    # append empty line to the end of the file
+    with open(table_path, "a") as f:
+        f.write("\n\t\n")
+
+    # ---- reload & verify it fails ----
+    with pytest.raises(RuntimeError) as exc_info:
+        test_table = DataclassTable(
+            dataclass_type=TableLineForTesting,
+            filepath=table_path,
+            logger=logger,
+        )
+        assert "failed to parse line from csv file" in str(exc_info.value)


### PR DESCRIPTION
This pull request improves the handling of CSV serialization and deserialization in the `dataclass_table` utility, ensuring robust support for fields containing special characters such as delimiters, tabs, and commas. It also extends the test coverage to verify correct behavior with such edge cases.

**CSV Handling Improvements:**

* Updated `_line_from_obj` and `__obj_from_line` methods in `dataclass_table.py` to use Python's built-in `csv` module for writing and reading lines, ensuring proper escaping and parsing of special characters in fields. [[1]](diffhunk://#diff-8246294b4179ef62a7ec8c9a9e27da0e5d6dd7f691f71d5f43c10fe8d6c48addR9) [[2]](diffhunk://#diff-8246294b4179ef62a7ec8c9a9e27da0e5d6dd7f691f71d5f43c10fe8d6c48addR18) [[3]](diffhunk://#diff-8246294b4179ef62a7ec8c9a9e27da0e5d6dd7f691f71d5f43c10fe8d6c48addL339-R359)

**Testing Enhancements:**

* Added a new `weird_field` to the `TableLineForTesting` dataclass and included test entries with values containing delimiters, tabs, and commas to verify correct CSV handling. [[1]](diffhunk://#diff-23e79fb9776983ce37d5d62fdf60b91975c043020cdc2485090bdbd61f17f137R23) [[2]](diffhunk://#diff-23e79fb9776983ce37d5d62fdf60b91975c043020cdc2485090bdbd61f17f137R39) [[3]](diffhunk://#diff-23e79fb9776983ce37d5d62fdf60b91975c043020cdc2485090bdbd61f17f137R52) [[4]](diffhunk://#diff-23e79fb9776983ce37d5d62fdf60b91975c043020cdc2485090bdbd61f17f137R65)
* Added assertions to confirm that the table correctly indexes and retrieves entries by the new `weird_field`, ensuring that special characters do not break the keying logic.