### PR TITLE
[girder] add pertinent info to user-agent header

### DIFF
--- a/openmsistream/girder/girder_upload_stream_processor.py
+++ b/openmsistream/girder/girder_upload_stream_processor.py
@@ -202,6 +202,17 @@ class GirderUploadStreamProcessor(DataFileStreamProcessor):
             session = requests.Session()
             session.mount("http://", self.http_adapter)
             session.mount("https://", self.http_adapter)
+            session.headers.update(
+                {
+                    "User-Agent": (
+                        f"OpenMSIStream/{openmsistream_version} "
+                        f"({self.__class__.__name__}; "
+                        f"{self.minimal_metadata_dict['KafkaTopic']}) "
+                        f"girder-client/{girder_client.__version__} "
+                        f"python-requests/{requests.__version__}"
+                    ),
+                }
+            )
             self._thread_local.session = session
         return self._thread_local.session
 


### PR DESCRIPTION
This pull request introduces an improvement to the HTTP session configuration in the `girder_upload_stream_processor.py` file. The main change is the addition of a detailed and informative `User-Agent` header to all outgoing HTTP requests, which includes versioning and context information for easier tracking and debugging.

HTTP Session Enhancement:

* Added a custom `User-Agent` header to the session in the `session` property, including `OpenMSIStream` version, processor class name, Kafka topic, `girder-client` version, and `requests` version.