### PR TITLE
Update readthedocs build.os version to ubuntu-24.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.9"
   apt_packages:


### PR DESCRIPTION
ReadtheDocs ("RtD") is removing support for the Ubuntu 20.04 LTS build image on Jun 1st, 2026 because it's an older image and it's no longer receiving security updates. For more info see [the blog post here](https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/).

Currently, OpenMSIStream is using the Ubuntu 20.04 image on RtD, so it needs to be updated. This PR makes the one-line change to update the build.os to the currently-recommended Ubuntu 24.04 instead.