### PR TITLE
Removed flawed replace_existing logic for hashsum_download case

### DIFF
--- a/openmsistream/girder/girder_upload_stream_processor.py
+++ b/openmsistream/girder/girder_upload_stream_processor.py
@@ -303,14 +303,22 @@ class GirderUploadStreamProcessor(DataFileStreamProcessor):
                 existing_item.get("meta", {}).get("checksum", {}).get("sha256")
                 == checksum_hash
             )
-            if not (same_file or self.replace_existing):
+            if same_file:
+                msg = (
+                    f"Found an existing Item named {datafile.filename} with the same "
+                    f"checksum in the folder at {datafile.relative_filepath}. Skipping upload."
+                )
+                self.logger.info(msg)
+                return None
+
+            if not self.replace_existing:
                 msg = (
                     f"Found an existing Item named {datafile.filename} in the folder at "
                     f"{datafile.relative_filepath}, but it has a different checksum than "
                     "the file being uploaded. "
                     "(Use --replace_existing to overwrite.)"
                 )
-                self.logger.info(msg)
+                self.logger.warning(msg)
                 return None
 
             try:

--- a/openmsistream/girder/girder_upload_stream_processor.py
+++ b/openmsistream/girder/girder_upload_stream_processor.py
@@ -8,7 +8,6 @@ from io import BytesIO
 import girder_client
 import requests
 from requests.adapters import HTTPAdapter
-from requests.exceptions import HTTPError
 from urllib3.util.retry import Retry
 
 from ..data_file_io.actor.data_file_stream_processor import DataFileStreamProcessor
@@ -59,19 +58,8 @@ class GirderClientWithSession(girder_client.GirderClient):
         self._session = session
 
     def existing_resource(self, datafile, folder_id):
-        try:
-            hashsum = datafile.check_file_hash
-            resp = self.get(f"hashsum/sha512/{hashsum}")
-            resp.raise_for_status()  # if hashsum_download is not installed it will throw 404
-            for fobj in resp:
-                item = self.get(f"item/{fobj['itemId']}")
-                if not item["folderId"] == folder_id:
-                    continue
-                return fobj, item
-        except HTTPError:
-            # fallback to checking for existing file by name
-            for item in self.listItem(folder_id, name=datafile.filename):
-                return next(self.listFile(item["_id"]), None), item
+        for item in self.listItem(folder_id, name=datafile.filename):
+            return next(self.listFile(item["_id"]), None), item
         return None, None
 
     def replace_existing_file(self, datafile, file_obj, mimetype=None):
@@ -309,7 +297,9 @@ class GirderUploadStreamProcessor(DataFileStreamProcessor):
             datafile, parent_id
         )
         if existing_item and existing_file:
-            same_file = (existing_file.get("sha512") == datafile.check_file_hash) or (
+            same_file = (
+                existing_file.get("sha512") == datafile.check_file_hash.hex()
+            ) or (
                 existing_item.get("meta", {}).get("checksum", {}).get("sha256")
                 == checksum_hash
             )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,7 +43,8 @@ from .test_scripts.test_data_file_stream_processor import (
 )
 
 ################## GENERAL PURPOSE FIXTURES ##################
-GIRDER_API_URL = "http://localhost:8080/api/v1"
+_GIRDER_IMAGE = "girder/girder:v5.0.0a14-py3"
+_GIRDER_INTERNAL_PORT = 8080
 HEADERS = {"Content-Type": "application/json", "Accept": "application/json"}
 GIRDER_TIMEOUT = 10
 
@@ -505,87 +506,125 @@ def run_controlled_process_test():
 
 
 @pytest.fixture(scope="module")
-def girder_instance():
+def girder_instance(request):
+    """
+    Spin up a Girder stack (MongoDB + Redis + Girder) using testcontainers.
+
+    Pass a list of extra pip packages to install into the Girder image before
+    it starts by parametrizing indirectly::
+
+        @pytest.mark.parametrize("girder_instance", [["my_plugin"]], indirect=True)
+        def test_with_plugin(girder_instance): ...
+    """
+    extra_plugins = list(getattr(request, "param", None) or [])
+
     try:
         docker.from_env()
     except docker.errors.DockerException:
         pytest.skip("Docker not running")
 
-    compose_file = TEST_CONST.TEST_DIR_PATH / "local-girder-docker-compose.yml"
+    network = Network()
 
-    # Tear down any leftover containers from a previous run to ensure a clean DB
-    subprocess.call(
-        ["docker", "compose", "-f", str(compose_file), "down", "-t", "0"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+    mongo = (
+        DockerContainer("mongo:4.4").with_network(network).with_network_aliases("mongodb")
     )
-    subprocess.check_output(["docker", "compose", "-f", str(compose_file), "up", "-d"])
-
-    # wait for API
-    for _ in range(30):
-        try:
-            r = requests.get(GIRDER_API_URL, timeout=GIRDER_TIMEOUT)
-            if r.status_code == 200:
-                break
-        except requests.exceptions.ConnectionError:
-            pass
-        time.sleep(1)
+    redis_ct = (
+        DockerContainer("redis:latest")
+        .with_network(network)
+        .with_network_aliases("redis")
+    )
+    girder_ct = (
+        DockerContainer(_GIRDER_IMAGE)
+        .with_network(network)
+        .with_network_aliases("girder")
+        .with_exposed_ports(_GIRDER_INTERNAL_PORT)
+        .with_env("GIRDER_MONGO_URI", "mongodb://mongodb:27017/girder")
+        .with_env("GIRDER_HOST", "0.0.0.0")
+        .with_env("GIRDER_WORKER_BROKER", "redis://redis/")
+        .with_env("GIRDER_WORKER_BACKEND", "redis://redis/")
+        .with_env("GIRDER_NOTIFICATION_REDIS_URL", "redis://redis:6379")
+    )
+    if extra_plugins:
+        plugins_str = " ".join(extra_plugins)
+        girder_ct = girder_ct.with_kwargs(entrypoint="bash").with_command(
+            ["-c", f"pip install {plugins_str} && girder serve -H 0.0.0.0"]
+        )
     else:
-        raise RuntimeError("Girder never became available")
+        girder_ct = girder_ct.with_command(["-H", "0.0.0.0"])
 
-    # create admin
-    r = requests.post(
-        f"{GIRDER_API_URL}/user",
-        headers=HEADERS,
-        params=dict(
-            login="admin",
-            email="root@dev.null",
-            firstName="John",
-            lastName="Doe",
-            password="arglebargle123",
-            admin=True,
-        ),
-        timeout=GIRDER_TIMEOUT,
-    )
+    with network:
+        mongo.start()
+        redis_ct.start()
+        girder_ct.start()
 
-    if r.status_code == 400:
-        raise RuntimeError("Girder DB not clean")
+        try:
+            host_port = girder_ct.get_exposed_port(_GIRDER_INTERNAL_PORT)
+            api_url = f"http://localhost:{host_port}/api/v1"
 
-    token = r.json()["authToken"]["token"]
-    headers = {**HEADERS, "Girder-Token": token}
+            # Wait for the API to become available
+            for _ in range(60):
+                try:
+                    r = requests.get(api_url, timeout=GIRDER_TIMEOUT)
+                    if r.status_code == 200:
+                        break
+                except requests.exceptions.ConnectionError:
+                    pass
+                time.sleep(1)
+            else:
+                raise RuntimeError("Girder never became available")
 
-    # create assetstore
-    r = requests.post(
-        f"{GIRDER_API_URL}/assetstore",
-        headers=headers,
-        params=dict(
-            type=0,
-            name="Base",
-            root="/home/girder/data/base",
-        ),
-        timeout=GIRDER_TIMEOUT,
-    )
-    assetstore_id = r.json()["_id"]
+            # Create admin user
+            r = requests.post(
+                f"{api_url}/user",
+                headers=HEADERS,
+                params=dict(
+                    login="admin",
+                    email="root@dev.null",
+                    firstName="John",
+                    lastName="Doe",
+                    password="arglebargle123",
+                    admin=True,
+                ),
+                timeout=GIRDER_TIMEOUT,
+            )
+            if r.status_code == 400:
+                raise RuntimeError("Girder DB not clean")
 
-    # create API key
-    r = requests.post(
-        f"{GIRDER_API_URL}/api_key",
-        headers=headers,
-        timeout=GIRDER_TIMEOUT,
-    )
-    api_key = r.json()["key"]
-    api_key_id = r.json()["_id"]
+            token = r.json()["authToken"]["token"]
+            headers = {**HEADERS, "Girder-Token": token}
 
-    yield {
-        "api_url": GIRDER_API_URL,
-        "api_key": api_key,
-        "api_key_id": api_key_id,
-        "assetstore_id": assetstore_id,
-    }
+            # Create assetstore
+            r = requests.post(
+                f"{api_url}/assetstore",
+                headers=headers,
+                params=dict(
+                    type=0,
+                    name="Base",
+                    root="/home/girder/data/base",
+                ),
+                timeout=GIRDER_TIMEOUT,
+            )
+            assetstore_id = r.json()["_id"]
 
-    subprocess.check_output(
-        ["docker", "compose", "-f", str(compose_file), "down", "-t", "0"]
-    )
+            # Create API key
+            r = requests.post(
+                f"{api_url}/api_key",
+                headers=headers,
+                timeout=GIRDER_TIMEOUT,
+            )
+            api_key = r.json()["key"]
+            api_key_id = r.json()["_id"]
+
+            yield {
+                "api_url": api_url,
+                "api_key": api_key,
+                "api_key_id": api_key_id,
+                "assetstore_id": assetstore_id,
+            }
+        finally:
+            girder_ct.stop()
+            redis_ct.stop()
+            mongo.stop()
 
 
 ################## MINIO (S3) FIXTURES ##################

--- a/test/test_scripts/test_girder_upload_stream_processor.py
+++ b/test/test_scripts/test_girder_upload_stream_processor.py
@@ -387,6 +387,15 @@ def test_girder_replace_existing(
     assert len(list(gc.listItem(root_folder["_id"]))) == 1
 
     # Try to upload again without replace - should skip
+    datafile1 = mock_datafile(
+        content=content_v1,
+        filename="versioned.txt",
+        subdir_str="",
+    )
+    with caplog.at_level("INFO"):
+        processor1._process_downloaded_data_file(datafile1, Lock())
+    assert "Skipping upload" in caplog.text
+
     content_v2 = b"Version 2 content (different)"
     datafile2 = mock_datafile(
         content=content_v2,

--- a/test/test_scripts/test_girder_upload_stream_processor.py
+++ b/test/test_scripts/test_girder_upload_stream_processor.py
@@ -347,6 +347,12 @@ def test_girder_upload_mimetype(
 
 @pytest.mark.kafka
 @responses.activate
+@pytest.mark.parametrize(
+    "girder_instance",
+    [[], ["girder_hashsum_download"]],
+    indirect=True,
+    ids=["plain", "with_hashsum_download"],
+)
 def test_girder_replace_existing(
     mock_datafile, girder_instance, tmp_path, apply_kafka_env, caplog
 ):
@@ -354,6 +360,9 @@ def test_girder_replace_existing(
     api_url = girder_instance["api_url"]
     api_key = girder_instance["api_key"]
     responses.add_passthru(api_url)  # Allow real requests to Girder
+    gc = girder_client.GirderClient(apiUrl=api_url)
+    gc.authenticate(apiKey=api_key)
+    folder_path = f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/{TOPIC_NAME}"
 
     # First upload without replace_existing
     processor1 = GirderUploadStreamProcessor(
@@ -374,6 +383,8 @@ def test_girder_replace_existing(
 
     result = processor1._process_downloaded_data_file(datafile1, Lock())
     assert result is None
+    root_folder = gc.get("resource/lookup", parameters={"path": folder_path})
+    assert len(list(gc.listItem(root_folder["_id"]))) == 1
 
     # Try to upload again without replace - should skip
     content_v2 = b"Version 2 content (different)"
@@ -385,11 +396,10 @@ def test_girder_replace_existing(
 
     result = processor1._process_downloaded_data_file(datafile2, Lock())
     assert result is None  # Should succeed but skip upload
+    root_folder = gc.get("resource/lookup", parameters={"path": folder_path})
+    assert len(list(gc.listItem(root_folder["_id"]))) == 1
 
     # Verify content is still v1
-    gc = girder_client.GirderClient(apiUrl=api_url)
-    gc.authenticate(apiKey=api_key)
-
     gpath = f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/{TOPIC_NAME}/versioned.txt"
     item = gc.get("resource/lookup", parameters={"path": gpath})
     file_id = next(f["_id"] for f in gc.listFile(item["_id"]))
@@ -431,6 +441,9 @@ def test_girder_replace_existing(
     responses.add_passthru(api_url)  # Allow real requests again
     result = processor2._process_downloaded_data_file(datafile3, Lock())
     assert result is None
+
+    root_folder = gc.get("resource/lookup", parameters={"path": folder_path})
+    assert len(list(gc.listItem(root_folder["_id"]))) == 1
 
     # Verify content is now v2
     item = gc.get("resource/lookup", parameters={"path": gpath})
@@ -587,3 +600,231 @@ def test_girder_odd_failures(
         assert isinstance(result, Exception)
     responses.reset()
     responses.add_passthru(api_url)
+
+    @pytest.mark.kafka
+    @pytest.mark.parametrize(
+        "kafka_topics",
+        [{TOPIC_NAME: {}}],
+        indirect=True,
+    )
+    def test_run_from_command_line(
+        kafka_topics,
+        girder_instance,
+        upload_file_helper,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        """Test run_from_command_line method."""
+        api_url = girder_instance["api_url"]
+        api_key = girder_instance["api_key"]
+
+        # Upload a file to Kafka first
+        upload_file_helper(
+            TEST_CONST.TEST_DATA_FILE_2_PATH,
+            topic_name=TOPIC_NAME,
+            rootdir=TEST_CONST.TEST_DATA_DIR_PATH,
+        )
+
+        # Mock process_files_as_read to return after processing one file
+        original_process = GirderUploadStreamProcessor.process_files_as_read
+
+        def mock_process(self):
+            result = original_process(self)
+            # Stop after processing
+            return result
+
+        monkeypatch.setattr(
+            GirderUploadStreamProcessor, "process_files_as_read", mock_process
+        )
+
+        # Prepare command line arguments
+        args = [
+            api_url,
+            api_key,
+            str(TEST_CONST.TEST_CFG_FILE_PATH),
+            TOPIC_NAME,
+            "--consumer_group_id",
+            f"pytest_{TOPIC_NAME}",
+            "--collection_name",
+            COLLECTION_NAME,
+            "--n_most_recent_files_to_check",
+            "1",
+        ]
+
+        with caplog.at_level("INFO"):
+            GirderUploadStreamProcessor.run_from_command_line(args=args)
+
+            # Verify logging messages
+            assert f"Listening to the {TOPIC_NAME} topic" in caplog.text
+            assert "Girder upload stream processor" in caplog.text
+            assert "shut down" in caplog.text
+            assert "total messages were consumed" in caplog.text
+            assert "files were uploaded to Girder" in caplog.text
+
+        # Verify the file was uploaded
+        gc = girder_client.GirderClient(apiUrl=api_url)
+        gc.authenticate(apiKey=api_key)
+
+        rel = TEST_CONST.TEST_DATA_FILE_2_PATH.relative_to(TEST_CONST.TEST_DATA_DIR_PATH)
+        gpath = f"/collection/{COLLECTION_NAME}/{COLLECTION_NAME}/{TOPIC_NAME}/{rel.name}"
+        item = gc.get("resource/lookup", parameters={"path": gpath})
+        assert item["_modelType"] == "item"
+
+        # Cleanup
+        gc.delete(f"/item/{item['_id']}")
+
+    @pytest.mark.kafka
+    @pytest.mark.parametrize(
+        "kafka_topics",
+        [{TOPIC_NAME: {}}],
+        indirect=True,
+    )
+    def test_run_from_command_line_with_output_dir(
+        kafka_topics,
+        girder_instance,
+        upload_file_helper,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        """Test run_from_command_line with output_dir specified."""
+        api_url = girder_instance["api_url"]
+        api_key = girder_instance["api_key"]
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        # Upload a file to Kafka
+        upload_file_helper(
+            TEST_CONST.TEST_DATA_FILE_2_PATH,
+            topic_name=TOPIC_NAME,
+            rootdir=TEST_CONST.TEST_DATA_DIR_PATH,
+        )
+
+        # Mock to stop after one file
+        original_process = GirderUploadStreamProcessor.process_files_as_read
+
+        def mock_process(self):
+            return original_process(self)
+
+        monkeypatch.setattr(
+            GirderUploadStreamProcessor, "process_files_as_read", mock_process
+        )
+
+        args = [
+            api_url,
+            api_key,
+            str(TEST_CONST.TEST_CFG_FILE_PATH),
+            TOPIC_NAME,
+            "--consumer_group_id",
+            f"pytest_{TOPIC_NAME}_output",
+            "--collection_name",
+            COLLECTION_NAME,
+            "--output_dir",
+            str(output_dir),
+            "--n_most_recent_files_to_check",
+            "1",
+        ]
+
+        with caplog.at_level("INFO"):
+            GirderUploadStreamProcessor.run_from_command_line(args=args)
+
+            # Verify the output_dir is mentioned in shutdown message
+            assert f"writing to {output_dir}" in caplog.text
+            assert "shut down" in caplog.text
+
+    @pytest.mark.kafka
+    @pytest.mark.parametrize(
+        "kafka_topics",
+        [{TOPIC_NAME: {}}],
+        indirect=True,
+    )
+    def test_run_from_command_line_debug_logging(
+        kafka_topics,
+        girder_instance,
+        upload_file_helper,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        """Test that debug logging shows uploaded filepaths."""
+        api_url = girder_instance["api_url"]
+        api_key = girder_instance["api_key"]
+
+        upload_file_helper(
+            TEST_CONST.TEST_DATA_FILE_2_PATH,
+            topic_name=TOPIC_NAME,
+            rootdir=TEST_CONST.TEST_DATA_DIR_PATH,
+        )
+
+        original_process = GirderUploadStreamProcessor.process_files_as_read
+
+        def mock_process(self):
+            return original_process(self)
+
+        monkeypatch.setattr(
+            GirderUploadStreamProcessor, "process_files_as_read", mock_process
+        )
+
+        args = [
+            api_url,
+            api_key,
+            str(TEST_CONST.TEST_CFG_FILE_PATH),
+            TOPIC_NAME,
+            "--consumer_group_id",
+            f"pytest_{TOPIC_NAME}_debug",
+            "--collection_name",
+            COLLECTION_NAME,
+            "--n_most_recent_files_to_check",
+            "1",
+        ]
+
+        with caplog.at_level("DEBUG"):
+            GirderUploadStreamProcessor.run_from_command_line(args=args)
+
+            # Should see debug message with filepath
+            assert "successfully uploaded to Girder" in caplog.text
+            assert "Uploaded filepaths" in caplog.text
+
+    @pytest.mark.kafka
+    def test_run_from_command_line_no_files(
+        girder_instance,
+        tmp_path,
+        monkeypatch,
+        caplog,
+        apply_kafka_env,
+    ):
+        """Test run_from_command_line when no files are processed."""
+        api_url = girder_instance["api_url"]
+        api_key = girder_instance["api_key"]
+
+        # Mock to return immediately with no files
+        def mock_process(self):
+            return 0, 0, 0, []
+
+        monkeypatch.setattr(
+            GirderUploadStreamProcessor, "process_files_as_read", mock_process
+        )
+
+        args = [
+            api_url,
+            api_key,
+            str(TEST_CONST.TEST_CFG_FILE_PATH),
+            f"{TOPIC_NAME}_empty",
+            "--consumer_group_id",
+            f"pytest_{TOPIC_NAME}_empty",
+            "--collection_name",
+            COLLECTION_NAME,
+        ]
+
+        with caplog.at_level("INFO"):
+            GirderUploadStreamProcessor.run_from_command_line(args=args)
+
+            # Should still show completion messages
+            assert "0 total messages were consumed" in caplog.text
+            assert "0 files were uploaded to Girder" in caplog.text
+            assert "shut down" in caplog.text
+
+        # Should NOT have debug filepath message since no files processed
+        with caplog.at_level("DEBUG"):
+            assert "Uploaded filepaths" not in caplog.text


### PR DESCRIPTION
This logical branch was previously untested. Now I added an actual test (rewrote girder fixture to pass optional plugins in the test request) and it exposed a logical flaw in it. I'm dropping it entirely and preserving the original approach as the only way of checking if the file exists.